### PR TITLE
WIP: Implementation of an external interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,9 @@ if (${ooo}_BUILD_TESTING)
     add_subdirectory(tests)
 endif()
 
+# Compile the external interface library
+add_subdirectory(src)
+
 set(export_properties
   "${ooo}_VERSION"
   )

--- a/openorbitaloptimizer/scfsolver.hpp
+++ b/openorbitaloptimizer/scfsolver.hpp
@@ -2039,6 +2039,7 @@ namespace OpenOrbitalOptimizer {
         callback_data["dE"] = get_energy() - old_energy_;
         callback_data["diis_error"] = diis_error;
         callback_data["diis_max_error"] = diis_max_error;
+        callback_data["history_size"] = orbital_history_.size();
 
         if(verbosity_>=5) {
           printf("\n\n");
@@ -2172,6 +2173,7 @@ namespace OpenOrbitalOptimizer {
         callback_data["diis_error"] = diis_error;
         callback_data["diis_max_error"] = diis_max_error;
         callback_data["step"] = std::string("ODA");
+        callback_data["history_size"] = orbital_history_.size();
 
         // Convergence check
         if(converged()) {

--- a/openorbitaloptimizer/scfsolver.hpp
+++ b/openorbitaloptimizer/scfsolver.hpp
@@ -2444,7 +2444,7 @@ namespace OpenOrbitalOptimizer {
       }
     }
 
-    void callback_function(std::function<void(const std::map<std::string,std::any> &)> callback_function = nullptr) {
+    void callback_function(std::function<void(const std::map<std::string,std::any> &)> callback_function) {
       callback_function_ = callback_function;
     }
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_library(
+  copenorbital
+  SHARED
+  extern.cpp
+)
+target_link_libraries(
+  copenorbital
+  PRIVATE
+    ${ooo}::OpenOrbitalOptimizer
+  )

--- a/src/extern.cpp
+++ b/src/extern.cpp
@@ -46,6 +46,7 @@ double rhf_solve_nosym_cpp(
   if (conv > 0.0) {
     scfsolver.convergence_threshold(conv);
   }
+  scfsolver.callback_function(callback_function);
   scfsolver.initialize_with_orbitals(Cv, nv);
   scfsolver.run();
 

--- a/src/extern.cpp
+++ b/src/extern.cpp
@@ -1,0 +1,77 @@
+#include "openorbitaloptimizer/scfsolver.hpp"
+
+double rhf_solve_nosym_cpp(
+    void (*c_fock_builder)(int64_t Norb, const double *C, const double *n, double *F, double *Etot),
+    void (*c_print_callback)(int64_t iter, double energy, double denergy, double maxerror, int64_t diis_dim),
+    int64_t Norb, int64_t Nelec, double *Cp, double *np, double conv) {
+  // Guess orbitals
+  arma::mat C(Cp, Norb, Norb, false, true);
+
+  // Guess occupations
+  arma::vec n(np, Norb, false, true);
+
+  // Fock builder
+  std::function<std::pair<double, OpenOrbitalOptimizer::FockMatrix<double>>(const OpenOrbitalOptimizer::DensityMatrix<double, double> & dm)> fock_builder = [&](const OpenOrbitalOptimizer::DensityMatrix<double, double> & dm) {
+    const auto & orbitals = dm.first;
+    const auto & occupations = dm.second;
+
+    std::vector<arma::mat> F(1);
+    F[0].resize(orbitals[0].n_cols, orbitals[0].n_cols);
+    F[0].zeros();
+    double Etot;
+
+    c_fock_builder(orbitals[0].n_cols, orbitals[0].memptr(), occupations[0].memptr(), F[0].memptr(), &Etot);
+    return std::make_pair(Etot,F);
+  };
+
+  std::function<void(const std::map<std::string,std::any> &)> callback_function = [&](const std::map<std::string,std::any> & data) {
+    double E = std::any_cast<double>(data.at("E"));
+    double dE = std::any_cast<double>(data.at("dE"));
+    double derror = std::any_cast<double>(data.at("diis_max_error"));
+    // TODO: figure out how to handle this
+    //std::string step = std::any_cast<std::string>(data.at("step"));
+
+    int64_t iter = std::any_cast<size_t>(data.at("iter"));
+    int64_t stacksize = 0;
+    c_print_callback(iter, E, dE, derror, stacksize);
+  };
+
+  // Number of blocks per particle type
+  arma::uvec number_of_blocks_per_particle_type({1});
+  arma::vec maximum_occupation({2});
+  arma::vec number_of_particles({(double) Nelec});
+  std::vector<std::string> block_descriptions(1);
+  block_descriptions[0]="alpha";
+
+  // Need to pad orbitals into vector
+  std::vector<arma::vec> nv(1);
+  nv[0]=n;
+  std::vector<arma::mat> Cv(1);
+  Cv[0]=C;
+
+  OpenOrbitalOptimizer::SCFSolver scfsolver(number_of_blocks_per_particle_type, maximum_occupation, number_of_particles, fock_builder, block_descriptions);
+  scfsolver.verbosity(0);
+  if (conv > 0.0) {
+    scfsolver.convergence_threshold(convergence_threshold);
+  }
+  scfsolver.initialize_with_orbitals(Cv, nv);
+  scfsolver.run();
+
+  // Get solution
+  auto density_matrix = scfsolver.get_solution();
+  auto orbitals = density_matrix.first;
+  auto occupations = density_matrix.second;
+  C = orbitals[0];
+  n = occupations[0];
+
+  auto fock_build = scfsolver.get_fock_build();
+  return fock_build.first;
+}
+
+extern "C" {
+  /** Solves RHF/RKS without symmetry. The orbital and Fock matrices are Norb x Norb. */
+  double rhf_solve_nosym(void (*c_fock_builder)(int64_t Norb, const double *C, const double *n, double *F, double *Etot), int64_t Norb, int64_t Nelec, double* Cp, double *np, double conv) {
+    return rhf_solve_nosym_cpp(c_fock_builder, Norb, Nelec, Cp, np, conv);
+  }
+}
+


### PR DESCRIPTION
This PR implements an instantiated interface to external programs, accessible in C or Fortran.

Right now, it only implements spin-restricted calculations without symmetry, but extending to symmetry and other types of wave functions will be straightforward once we nail down the interface.

The big questions here are
- how to pass in parameters to OOO? This is essentially related to #4, and the best solution likely is to get rid of the individual setters and getters and instead just have a `std::map<std::string,std::any>` to store the various data.
- how to generalize the plugin infrastructure such that it is easier to access various variables in OOO? This again is likely easiest to handle with a `std::map<std::string,std::any>` which is already used in the C++ callback; we just need to figure out how to enable getting values one by one.