### PR TITLE
Python bindings for OpenOrbitalOptimizer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -182,6 +182,77 @@ jobs:
         cmake --build . --target atomtest
         ./atomtest --Z 8 --xfunc GGA_X_PBE --cfunc GGA_C_PBE --M 3 --sto 0 --basis "${{github.workspace}}/tests/cc-pvdz.json"
 
+  build-test-python:
+    strategy:
+      fail-fast: false
+      matrix:
+        cfg:
+          - lane: linux-gnu
+            runs-on: ubuntu-latest
+            python-version: "3.10"
+
+    name: "Python • 🐍 ${{ matrix.cfg.python-version }} • ${{ matrix.cfg.lane }}"
+    runs-on: ${{ matrix.cfg.runs-on }}
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+    - name: Checkout OpenOrbitalOptimizer
+      uses: actions/checkout@v4
+
+    - name: Write a Conda Env File
+      run: |
+        cat > export-py.yaml <<EOF
+        name: test-py
+        channels:
+          - conda-forge
+        dependencies:
+          - cmake
+          - ninja
+          - cxx-compiler
+          - armadillo
+          - pybind11
+          - numpy
+          - pytest
+          - pyscf
+        EOF
+        cat export-py.yaml
+
+    - name: Create Conda Environment
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        python-version: ${{ matrix.cfg.python-version }}
+        activate-environment: test-py
+        channels: conda-forge
+        environment-file: export-py.yaml
+        show-channel-urls: true
+        auto-activate-base: false
+        add-pip-as-python-dependency: true
+        conda-remove-defaults: true
+
+    - name: Environment Information
+      run: |
+        conda info
+        conda list
+
+    - name: Build OpenOrbitalOptimizer Python bindings
+      run: |
+        cmake \
+          -S . \
+          -B build-py \
+          -G "Ninja" \
+          -D CMAKE_BUILD_TYPE=Release \
+          -D OpenOrbitalOptimizer_BUILD_PYTHON=ON \
+          -D OpenOrbitalOptimizer_BUILD_TESTING=OFF \
+          -D CMAKE_CXX_COMPILER=${CXX} \
+          -D CMAKE_PREFIX_PATH="${CONDA_PREFIX}"
+        cmake --build build-py
+
+    - name: Run Python tests
+      run: |
+        PYTHONPATH="${PWD}/build-py/python" python -m pytest -v python/tests
+
   release_docs:
     needs: [build-test-repo]
     permissions:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,31 +11,36 @@ on:
 
 jobs:
   build-test-repo:
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
         cfg:
           - lane: linux-gnu
             runs-on: ubuntu-latest
-            python-version: "3.10"
+            python-version: "3.12"
             cmargs: ""
+          - lane: linux-clang
+            runs-on: ubuntu-latest
+            python-version: "3.12"
+            cmargs: >
+              -D CMAKE_CXX_COMPILER=clang++
           - lane: linux-icpx
             runs-on: ubuntu-latest
-            python-version: "3.10"
+            python-version: "3.12"
             cmargs: >
               -D CMAKE_CXX_COMPILER=icpx
+          - lane: linux-arm64-gnu
+            runs-on: ubuntu-24.04-arm
+            python-version: "3.12"
+            cmargs: ""
           - lane: macos-silicon-clang
             runs-on: macos-latest
-            python-version: "3.10"
+            python-version: "3.12"
             cmargs: ""
-          - lane: macos-intel-clang
-            runs-on: macos-13
-            python-version: "3.10"
-            cmargs: ""
-            # Library/include/ compensates for faulty conda windows config
           - lane: windows-clang
             runs-on: windows-latest
-            python-version: "3.10"
+            python-version: "3.12"
             cmargs: >
               -D CMAKE_CXX_COMPILER=clang-cl
               -D CMAKE_CXX_FLAGS="-I${CONDA_PREFIX}\\Library\\include"
@@ -48,15 +53,7 @@ jobs:
 
     steps:
     - name: Checkout OpenOrbitalOptimizer
-      uses: actions/checkout@v4
-
-    - name: Checkout IntegratorXX
-      uses: actions/checkout@v4
-      with:
-        #repository: wavefunction91/IntegratorXX
-        repository: loriab/IntegratorXX
-        ref: windows
-        path: IntXX
+      uses: actions/checkout@v5
 
     - name: Prepare compiler environment, vcvarsall (W)
       if: runner.os == 'Windows'
@@ -83,10 +80,12 @@ jobs:
           - liblapack * *netlib
           #- dummy1
         EOF
-        # MacOS: sed -E -i.bak "s;;;g" export.yaml
         if [[ "${{ matrix.cfg.lane }}" == "linux-icpx" ]]; then
-          :
           sed -i "s/#- dummy1/- dpcpp_linux-64/g" export.yaml
+        fi
+        if [[ "${{ matrix.cfg.lane }}" == "linux-clang" ]]; then
+          echo "  - clang_linux-64" >> export.yaml
+          echo "  - clangxx_linux-64" >> export.yaml
         fi
         cat export.yaml
 
@@ -98,7 +97,7 @@ jobs:
         channels: conda-forge
         environment-file: export.yaml
         show-channel-urls: true
-        auto-activate-base: false
+        auto-activate: false
         add-pip-as-python-dependency: true
         conda-remove-defaults: true
 
@@ -106,23 +105,6 @@ jobs:
       run: |
         conda info
         conda list
-
-    - name: Build & Install IntegratorXX
-      if: false
-      working-directory: ./IntXX
-      run: |
-        cmake \
-          -S . \
-          -B build \
-          -G "Ninja" \
-          -D CMAKE_BUILD_TYPE=Release \
-          -D CMAKE_INSTALL_PREFIX="${{github.workspace}}/installed" \
-          -D CMAKE_INSTALL_LIBDIR=lib \
-          -D CMAKE_CXX_COMPILER=${CXX} \
-          -D CMAKE_PREFIX_PATH="${CONDA_PREFIX}" \
-          -D INTEGRATORXX_ENABLE_TESTS=OFF \
-          ${{ matrix.cfg.cmargs }}
-        cmake --build build --target install
 
     - name: Build & Install OpenOrbitalOptimizer
       run: |
@@ -136,8 +118,6 @@ jobs:
           -D CMAKE_PREFIX_PATH="${CONDA_PREFIX};${CONDA_PREFIX}/Library" \
           ${{ matrix.cfg.cmargs }}
         cmake --build build --target install
-      # needed when build intXX from src
-      #   -D IntegratorXX_DIR="${{github.workspace}}/installed/lib/cmake/IntegratorXX"
 
     - name: Test
       run: ctest --output-on-failure --test-dir build/
@@ -183,15 +163,20 @@ jobs:
         ./atomtest --Z 8 --xfunc GGA_X_PBE --cfunc GGA_C_PBE --M 3 --sto 0 --basis "${{github.workspace}}/tests/cc-pvdz.json"
 
   build-test-python:
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         cfg:
           - lane: linux-gnu
             runs-on: ubuntu-latest
-            python-version: "3.10"
+          - lane: linux-arm64-gnu
+            runs-on: ubuntu-24.04-arm
+          - lane: macos-silicon-clang
+            runs-on: macos-latest
+        python-version: ["3.11", "3.12", "3.13"]
 
-    name: "Python • 🐍 ${{ matrix.cfg.python-version }} • ${{ matrix.cfg.lane }}"
+    name: "Python • 🐍 ${{ matrix.python-version }} • ${{ matrix.cfg.lane }}"
     runs-on: ${{ matrix.cfg.runs-on }}
     defaults:
       run:
@@ -199,7 +184,7 @@ jobs:
 
     steps:
     - name: Checkout OpenOrbitalOptimizer
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Write a Conda Env File
       run: |
@@ -222,12 +207,12 @@ jobs:
     - name: Create Conda Environment
       uses: conda-incubator/setup-miniconda@v3
       with:
-        python-version: ${{ matrix.cfg.python-version }}
+        python-version: ${{ matrix.python-version }}
         activate-environment: test-py
         channels: conda-forge
         environment-file: export-py.yaml
         show-channel-urls: true
-        auto-activate-base: false
+        auto-activate: false
         add-pip-as-python-dependency: true
         conda-remove-defaults: true
 
@@ -254,6 +239,7 @@ jobs:
         PYTHONPATH="${PWD}/build-py/python" python -m pytest -v python/tests
 
   release_docs:
+    timeout-minutes: 15
     needs: [build-test-repo]
     permissions:
       contents: write
@@ -265,14 +251,14 @@ jobs:
       matrix:
         cfg:
           - label: MkDocs
-            python-version: "3.10"
+            python-version: "3.12"
             runs-on: ubuntu-latest
 
     name: "🐍 ${{ matrix.cfg.python-version }} • ${{ matrix.cfg.label }}"
     runs-on: ${{ matrix.cfg.runs-on }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Write a Conda Env File
       run: |
@@ -300,7 +286,7 @@ jobs:
         activate-environment: test
         environment-file: export.yaml
         python-version: ${{ matrix.cfg.python-version }}
-        auto-activate-base: false
+        auto-activate: false
         show-channel-urls: true
         add-pip-as-python-dependency: true
         channels: conda-forge,nodefaults

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,9 @@ message(STATUS "Showing option ${ooo}_INSTALL_CMAKEDIR: ${${ooo}_INSTALL_CMAKEDI
 option(${ooo}_BUILD_TESTING "Build test-suite" ${PROJECT_IS_TOP_LEVEL})
 message(STATUS "Showing option ${ooo}_BUILD_TESTING: ${${ooo}_BUILD_TESTING}")
 
+option(${ooo}_BUILD_PYTHON "Build Python bindings via pybind11" OFF)
+message(STATUS "Showing option ${ooo}_BUILD_PYTHON: ${${ooo}_BUILD_PYTHON}")
+
 # ====  Build  ==================================================================
 add_library(libooo INTERFACE)
 
@@ -96,6 +99,10 @@ target_link_libraries(
 if (${ooo}_BUILD_TESTING)
     enable_testing()
     add_subdirectory(tests)
+endif()
+
+if (${ooo}_BUILD_PYTHON)
+    add_subdirectory(python)
 endif()
 
 set(export_properties

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,0 +1,32 @@
+find_package(pybind11 CONFIG REQUIRED)
+
+pybind11_add_module(_ext _ext.cpp)
+target_link_libraries(_ext PRIVATE ${ooo}::OpenOrbitalOptimizer)
+set_target_properties(
+  _ext
+  PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/openorbital
+  )
+
+# Copy the Python facade alongside the extension so the build tree
+# is directly importable as ``openorbital``.
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/openorbital/__init__.py
+  ${CMAKE_CURRENT_BINARY_DIR}/openorbital/__init__.py
+  COPYONLY
+  )
+
+# Optional install target: install both the extension and the Python
+# facade into the same site-packages directory.
+include(GNUInstallDirs)
+if (Python_SITELIB)
+  install(
+    TARGETS _ext
+    LIBRARY DESTINATION ${Python_SITELIB}/openorbital
+    )
+  install(
+    DIRECTORY openorbital/
+    DESTINATION ${Python_SITELIB}/openorbital
+    FILES_MATCHING PATTERN "*.py"
+    )
+endif()

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -9,12 +9,20 @@ set_target_properties(
   )
 
 # Copy the Python facade alongside the extension so the build tree
-# is directly importable as ``openorbital``.
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/openorbital/__init__.py
-  ${CMAKE_CURRENT_BINARY_DIR}/openorbital/__init__.py
-  COPYONLY
-  )
+# is directly importable as ``openorbital``. Mirror every .py file
+# under the source ``openorbital/`` package -- including subpackages
+# such as ``openorbital.pyscf`` -- into the build tree at the same
+# relative path.
+file(GLOB_RECURSE _ooo_py_files
+     RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/openorbital
+     ${CMAKE_CURRENT_SOURCE_DIR}/openorbital/*.py)
+foreach(_pyfile IN LISTS _ooo_py_files)
+  configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/openorbital/${_pyfile}
+    ${CMAKE_CURRENT_BINARY_DIR}/openorbital/${_pyfile}
+    COPYONLY
+    )
+endforeach()
 
 # Optional install target: install both the extension and the Python
 # facade into the same site-packages directory.

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,78 @@
+# OpenOrbitalOptimizer Python bindings
+
+A `pybind11`-based binding that exposes `SCFSolver<double, double>` from
+the header-only C++ library to Python. The bindings convert
+`arma::Mat<double>` and `arma::Col<double>` to F-contiguous NumPy
+arrays by copy; F order matches Armadillo's column-major layout, so no
+implicit transpose is performed.
+
+## Build
+
+Requires `pybind11` (3.x), Armadillo, and a C++17 compiler.
+
+```bash
+cmake -S . -B objdir-py \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DOpenOrbitalOptimizer_BUILD_PYTHON=ON \
+      -DOpenOrbitalOptimizer_BUILD_TESTING=OFF
+cmake --build objdir-py -j
+```
+
+The build tree's `objdir-py/python/openorbital/` is directly
+importable; add it to `PYTHONPATH` to use without installing:
+
+```bash
+PYTHONPATH=$PWD/objdir-py/python python python/tests/test_one_electron.py
+```
+
+## Usage
+
+The minimum-viable Python use:
+
+```python
+import numpy as np
+import openorbital
+
+def fock_builder(density):
+    orbitals_list, occupations_list = density
+    # ... compute F and E in the orthonormal basis you handed to the solver
+    return energy, [F]
+
+solver = openorbital.SCFSolver(
+    number_of_blocks_per_particle_type=np.array([1], dtype=np.uintp),
+    maximum_occupation=np.array([2.0]),
+    number_of_particles=np.array([1.0]),
+    fock_builder=fock_builder,
+    block_descriptions=["s"],
+)
+solver.convergence_threshold(1e-7)
+solver.initialize_with_fock([initial_fock_F_contiguous])
+solver.run()
+print(solver.get_energy(0))
+```
+
+## Conventions
+
+* The basis is always treated as **orthonormal**. The caller is
+  responsible for any AO -> orthonormal transformation (Löwdin,
+  canonical, Cholesky, ...).
+* Matrices are F-contiguous (column-major). NumPy arrays are
+  automatically force-cast to F order on the way into the binding;
+  arrays returned from the binding are F-contiguous by construction.
+* Particle types are independent (electrons, alpha/beta, NEO
+  protons). Each particle has one or more symmetry blocks; the
+  per-block `maximum_occupation` carries the spatial degeneracy of
+  that block (e.g. an atomic p-shell is one Armadillo block with
+  `max_occ = 6` for restricted or `3` for unrestricted; the three
+  magnetic components share the same radial Fock matrix).
+
+## Planned drivers (not in this scaffold)
+
+* `openorbital.pyscf.molecular`: an RHF/UHF/ROHF driver that wraps a
+  PySCF mean-field instance as a Fock builder.
+* `openorbital.pyscf.atomic`: an atomic SCF driver that builds one
+  block per `(n, l, spin)` shell.
+* `openorbital.pyscf.diatomic`: a diatomic SCF driver that builds
+  one block per `(Lambda, spin)` (and parity for D_inf_h), with
+  `max_occ` capturing the 2-fold m-degeneracy of pi, delta, ...
+  representations.

--- a/python/_ext.cpp
+++ b/python/_ext.cpp
@@ -1,0 +1,150 @@
+/*
+ Copyright (C) 2026- Susi Lehtola
+
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/functional.h>
+#include <pybind11/numpy.h>
+
+#include <armadillo>
+#include <cstring>
+
+#include <openorbitaloptimizer/scfsolver.hpp>
+
+namespace py = pybind11;
+
+/// pybind11 type casters between arma::Mat / arma::Col / arma::uvec and
+/// NumPy arrays. Conversion is by copy in both directions; the F-order
+/// layout of arma::Mat is exposed as an F-contiguous numpy array on the
+/// Python side, which matches the convention used elsewhere in the
+/// library and avoids implicit transposes.
+namespace pybind11 { namespace detail {
+
+template<>
+struct type_caster<arma::Mat<double>> {
+public:
+  PYBIND11_TYPE_CASTER(arma::Mat<double>, _("numpy.ndarray[float64, ndim=2]"));
+
+  bool load(handle src, bool /*convert*/) {
+    auto arr = array_t<double, array::f_style | array::forcecast>::ensure(src);
+    if (!arr) return false;
+    if (arr.ndim() != 2) return false;
+    value = arma::Mat<double>(arr.data(), arr.shape(0), arr.shape(1));
+    return true;
+  }
+
+  static handle cast(const arma::Mat<double> & src, return_value_policy, handle) {
+    array_t<double, array::f_style> out(
+      std::vector<py::ssize_t>{(py::ssize_t)src.n_rows, (py::ssize_t)src.n_cols}
+    );
+    if (src.n_elem > 0)
+      std::memcpy(out.mutable_data(), src.memptr(), src.n_elem * sizeof(double));
+    return out.release();
+  }
+};
+
+template<>
+struct type_caster<arma::Col<double>> {
+public:
+  PYBIND11_TYPE_CASTER(arma::Col<double>, _("numpy.ndarray[float64, ndim=1]"));
+
+  bool load(handle src, bool /*convert*/) {
+    auto arr = array_t<double, array::forcecast>::ensure(src);
+    if (!arr) return false;
+    if (arr.ndim() != 1) return false;
+    value = arma::Col<double>(arr.data(), arr.shape(0));
+    return true;
+  }
+
+  static handle cast(const arma::Col<double> & src, return_value_policy, handle) {
+    array_t<double> out(std::vector<py::ssize_t>{(py::ssize_t)src.n_elem});
+    if (src.n_elem > 0)
+      std::memcpy(out.mutable_data(), src.memptr(), src.n_elem * sizeof(double));
+    return out.release();
+  }
+};
+
+template<>
+struct type_caster<arma::uvec> {
+public:
+  PYBIND11_TYPE_CASTER(arma::uvec, _("numpy.ndarray[uint, ndim=1]"));
+
+  bool load(handle src, bool /*convert*/) {
+    auto arr = array_t<arma::uword, array::forcecast>::ensure(src);
+    if (!arr) return false;
+    if (arr.ndim() != 1) return false;
+    value = arma::uvec(arr.data(), arr.shape(0));
+    return true;
+  }
+
+  static handle cast(const arma::uvec & src, return_value_policy, handle) {
+    array_t<arma::uword> out(std::vector<py::ssize_t>{(py::ssize_t)src.n_elem});
+    if (src.n_elem > 0)
+      std::memcpy(out.mutable_data(), src.memptr(), src.n_elem * sizeof(arma::uword));
+    return out.release();
+  }
+};
+
+}} // namespace pybind11::detail
+
+PYBIND11_MODULE(_ext, m) {
+  m.doc() = "OpenOrbitalOptimizer Python bindings";
+
+  using namespace OpenOrbitalOptimizer;
+  using Solver = SCFSolver<double, double>;
+
+  py::class_<Solver>(m, "SCFSolver",
+      "SCF solver supporting fractional/degenerate occupations through\n"
+      "skeleton density matrices and bi-level ODA + preconditioned CG\n"
+      "minimization. Templated on (double, double).")
+    .def(py::init<arma::uvec, arma::Col<double>, arma::Col<double>,
+                  FockBuilder<double, double>, std::vector<std::string>>(),
+         py::arg("number_of_blocks_per_particle_type"),
+         py::arg("maximum_occupation"),
+         py::arg("number_of_particles"),
+         py::arg("fock_builder"),
+         py::arg("block_descriptions"),
+         "Construct an SCF solver. The Fock builder is a Python callable\n"
+         "taking (orbitals: list[ndarray], occupations: list[ndarray])\n"
+         "and returning (energy: float, fock: list[ndarray]).")
+    .def("verbosity",
+         py::overload_cast<int>(&Solver::verbosity),
+         py::arg("verbosity"))
+    .def("convergence_threshold",
+         py::overload_cast<double>(&Solver::convergence_threshold),
+         py::arg("threshold"))
+    .def("maximum_iterations",
+         py::overload_cast<size_t>(&Solver::maximum_iterations),
+         py::arg("max_iter"))
+    .def("initialize_with_fock",
+         &Solver::initialize_with_fock,
+         py::arg("fock"))
+    .def("initialize_with_orbitals",
+         &Solver::initialize_with_orbitals,
+         py::arg("orbitals"), py::arg("occupations"))
+    .def("run", &Solver::run,
+         "Run the hybrid DIIS / ODA+CG SCF loop.")
+    .def("run_optimal_damping", &Solver::run_optimal_damping,
+         "Run the standalone ODA+CG loop without DIIS.")
+    .def("get_solution", &Solver::get_solution,
+         py::arg("ihist") = 0,
+         "Return (orbitals, occupations) of the ihist:th entry.")
+    .def("get_orbitals", &Solver::get_orbitals,
+         py::arg("ihist") = 0,
+         "Return orbital coefficient blocks of the ihist:th entry.")
+    .def("get_orbital_occupations", &Solver::get_orbital_occupations,
+         py::arg("ihist") = 0,
+         "Return orbital occupation blocks of the ihist:th entry.")
+    .def("get_fock_matrix", &Solver::get_fock_matrix,
+         py::arg("ihist") = 0,
+         "Return Fock matrix blocks of the ihist:th entry.")
+    .def("get_energy",
+         py::overload_cast<size_t>(&Solver::get_energy, py::const_),
+         py::arg("ihist") = 0,
+         "Total energy of history entry ihist (0 = lowest energy).");
+}

--- a/python/openorbital/__init__.py
+++ b/python/openorbital/__init__.py
@@ -1,0 +1,19 @@
+"""OpenOrbitalOptimizer Python bindings.
+
+OpenOrbitalOptimizer is a header-only C++17 library for self-consistent
+field (SCF) orbital optimization in quantum chemistry. The library
+expects the caller to supply a Fock-builder callback that maps a
+density matrix to an energy and Fock matrix in an orthonormal basis;
+the library then performs DIIS / A-DIIS / E-DIIS extrapolation,
+optimal damping with skeleton density matrices for degenerate shells,
+and preconditioned Polak-Ribiere conjugate-gradient orbital rotations.
+
+The single class exposed by this binding is ``SCFSolver`` (for real
+orbital coefficients and real bases at double precision); the four
+template instantiations of the underlying C++ library can be added if
+the use case requires complex orbital coefficients or single precision.
+"""
+
+from ._ext import SCFSolver
+
+__all__ = ["SCFSolver"]

--- a/python/openorbital/pyscf/__init__.py
+++ b/python/openorbital/pyscf/__init__.py
@@ -5,6 +5,12 @@ for ``openorbital.SCFSolver``, providing a robust SCF convergence layer
 on top of PySCF's integral and exchange-correlation machinery.
 """
 
+from .atomic import OpenOrbitalAtomicSCF
+from .diatomic import OpenOrbitalDiatomicSCF
 from .molecular import OpenOrbitalSCF
 
-__all__ = ["OpenOrbitalSCF"]
+__all__ = [
+    "OpenOrbitalSCF",
+    "OpenOrbitalAtomicSCF",
+    "OpenOrbitalDiatomicSCF",
+]

--- a/python/openorbital/pyscf/__init__.py
+++ b/python/openorbital/pyscf/__init__.py
@@ -1,0 +1,10 @@
+"""PySCF integration for OpenOrbitalOptimizer.
+
+The submodule wraps PySCF mean-field instances as Fock-builder callbacks
+for ``openorbital.SCFSolver``, providing a robust SCF convergence layer
+on top of PySCF's integral and exchange-correlation machinery.
+"""
+
+from .molecular import OpenOrbitalSCF
+
+__all__ = ["OpenOrbitalSCF"]

--- a/python/openorbital/pyscf/atomic.py
+++ b/python/openorbital/pyscf/atomic.py
@@ -1,0 +1,259 @@
+"""Atomic SCF driver with enforced spherical symmetry.
+
+For an atomic calculation OpenOrbitalOptimizer is fed one block per
+``(l, spin)`` shell. Each radial function in the ``l`` shell is one
+``orbital`` from the solver's point of view, and the per-block
+``maximum_occupation`` carries the magnetic-component multiplicity:
+``2(2l+1)`` for restricted (s=2, p=6, d=10, f=14), ``2l+1`` for
+unrestricted (s=1, p=3, d=5, f=7).
+
+The Fock matrix per block is built by averaging the AO Fock over the
+``2l+1`` magnetic components of that shell, enforcing spherical
+invariance every iteration. Symmetric fractional occupations in
+partially filled degenerate shells (e.g. Fe d^6 -> 6/5 per m-component
+in the alpha channel) emerge automatically from OpenOrbitalOptimizer's
+skeleton enumeration.
+
+This driver expects a single-atom PySCF molecule with spherical AOs
+(``mol.cart == False``) and PySCF basis shells with one contracted
+function each. The standard BSE/PySCF basis sets satisfy both
+conditions.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from openorbital import SCFSolver
+
+from .molecular import _canonical_orthogonalizer
+
+
+_ANG_LABELS = {0: "s", 1: "p", 2: "d", 3: "f", 4: "g", 5: "h", 6: "i", 7: "k"}
+
+
+def _identify_atomic_l_shells(mol):
+    """Group radial basis functions by angular momentum.
+
+    Returns ``{l: list of ao_start_per_radial}``, where each entry is the
+    starting AO index of one radial function in spherical-AO order. A
+    PySCF shell with generalized contractions (n_ctr > 1) contributes
+    n_ctr entries to the list. Spherical AOs are assumed (``mol.cart ==
+    False``), with PySCF's ``(ctr, m)`` ordering (contraction outer,
+    magnetic component inner).
+    """
+    if mol.natm != 1:
+        raise ValueError(
+            "atomic driver requires single-atom mol; got natm=%d" % mol.natm)
+    if getattr(mol, "cart", False):
+        raise ValueError(
+            "atomic driver requires spherical AOs; rebuild mol with cart=False")
+
+    ao_loc = mol.ao_loc_nr()
+    shells_by_l = {}
+    for shell in range(mol.nbas):
+        l = mol.bas_angular(shell)
+        n_ctr = mol.bas_nctr(shell)
+        ao_start = ao_loc[shell]
+        expected = n_ctr * (2 * l + 1)
+        actual = ao_loc[shell + 1] - ao_start
+        if actual != expected:
+            raise ValueError(
+                "Shell %d has angular momentum %d and %d contractions but "
+                "%d AOs (expected %d); unsupported basis layout."
+                % (shell, l, n_ctr, actual, expected))
+        for ctr in range(n_ctr):
+            shells_by_l.setdefault(l, []).append(
+                ao_start + ctr * (2 * l + 1))
+    return shells_by_l
+
+
+class OpenOrbitalAtomicSCF:
+    """Atomic SCF driver wrapping a PySCF mean-field with spherical symmetry.
+
+    Parameters
+    ----------
+    mf : pyscf.scf.hf.SCF
+        Single-atom mean-field instance (RHF, RKS, UHF, UKS).
+    linear_dependency_threshold : float, optional
+        Per-``l`` overlap eigenvalues below this threshold are dropped
+        from the orthonormal radial basis. Default ``1e-8``.
+
+    Attributes
+    ----------
+    solver : openorbital.SCFSolver
+    e_tot : float or None
+    """
+
+    def __init__(self,
+                 mf,
+                 linear_dependency_threshold: float = 1e-8):
+        from pyscf.scf import uhf
+
+        self.mf = mf
+        self.mol = mf.mol
+        self._is_uhf = isinstance(mf, uhf.UHF)
+        self._nao = self.mol.nao_nr()
+
+        self._shells_by_l = _identify_atomic_l_shells(self.mol)
+        self._l_values = sorted(self._shells_by_l)
+        self._n_blocks = len(self._l_values)
+
+        # Per-l data: number of radial functions and (2l+1, n_radial) array
+        # of AO indices (one row per magnetic component).
+        self._n_radial = {}
+        self._m_aos = {}
+        for l in self._l_values:
+            radial_starts = self._shells_by_l[l]
+            n_radial = len(radial_starts)
+            self._n_radial[l] = n_radial
+            m_aos = np.zeros((2 * l + 1, n_radial), dtype=int)
+            for r, ao_start in enumerate(radial_starts):
+                for m in range(2 * l + 1):
+                    m_aos[m, r] = ao_start + m
+            self._m_aos[l] = m_aos
+
+        # Per-l canonical orthogonalizer on the radial-only overlap.
+        overlap = mf.get_ovlp()
+        self._X = {}
+        for l in self._l_values:
+            S_l = self._radialize(overlap, l)
+            self._X[l] = _canonical_orthogonalizer(
+                S_l, linear_dependency_threshold)
+
+        # Build solver. Block descriptions are spectroscopic labels.
+        block_descriptions = [_ANG_LABELS.get(l, "l=%d" % l)
+                              for l in self._l_values]
+        if self._is_uhf:
+            n_alpha, n_beta = self.mol.nelec
+            max_occ = np.array(
+                [2 * l + 1 for l in self._l_values] +
+                [2 * l + 1 for l in self._l_values], dtype=float)
+            self.solver = SCFSolver(
+                number_of_blocks_per_particle_type=np.array(
+                    [self._n_blocks, self._n_blocks], dtype=np.uintp),
+                maximum_occupation=max_occ,
+                number_of_particles=np.array(
+                    [float(n_alpha), float(n_beta)]),
+                fock_builder=self._fock_builder_unrestricted,
+                block_descriptions=[d + " alpha" for d in block_descriptions]
+                                 + [d + " beta" for d in block_descriptions],
+            )
+        else:
+            n_elec = self.mol.nelectron
+            max_occ = np.array(
+                [2 * (2 * l + 1) for l in self._l_values], dtype=float)
+            self.solver = SCFSolver(
+                number_of_blocks_per_particle_type=np.array(
+                    [self._n_blocks], dtype=np.uintp),
+                maximum_occupation=max_occ,
+                number_of_particles=np.array([float(n_elec)]),
+                fock_builder=self._fock_builder_restricted,
+                block_descriptions=block_descriptions,
+            )
+
+        self.e_tot = None
+
+    # --- helpers --------------------------------------------------------------
+
+    def _radialize(self, M_ao: np.ndarray, l: int) -> np.ndarray:
+        """Average a (nao, nao) AO matrix over the (2l+1) m-components of l."""
+        m_aos = self._m_aos[l]
+        n_radial = self._n_radial[l]
+        block = np.zeros((n_radial, n_radial))
+        for m in range(2 * l + 1):
+            ao_idx = m_aos[m]
+            block += M_ao[np.ix_(ao_idx, ao_idx)]
+        return block / (2 * l + 1)
+
+    def _density_from_orth(self,
+                           orbitals_orth_blocks,
+                           occupations_blocks) -> np.ndarray:
+        """AO density built from OOO's per-l orth orbitals.
+
+        For each radial orbital with occupation ``n`` the per-m
+        contribution is ``n / (2l+1)``; this is placed identically into
+        every m-block of the AO matrix, which keeps the AO density
+        block-diagonal in m and rotationally invariant.
+        """
+        P_ao = np.zeros((self._nao, self._nao))
+        for l, C_orth, n in zip(self._l_values,
+                                orbitals_orth_blocks,
+                                occupations_blocks):
+            if C_orth.size == 0:
+                continue
+            X = self._X[l]
+            C_radial = X @ C_orth
+            D_per_m = (C_radial * (n / (2 * l + 1))) @ C_radial.T
+            for m in range(2 * l + 1):
+                ao_idx = self._m_aos[l][m]
+                P_ao[np.ix_(ao_idx, ao_idx)] += D_per_m
+        return P_ao
+
+    def _fock_per_block(self, F_ao: np.ndarray):
+        out = []
+        for l in self._l_values:
+            F_l = self._radialize(F_ao, l)
+            X = self._X[l]
+            out.append(np.asfortranarray(X.T @ F_l @ X))
+        return out
+
+    # --- Fock-builder callbacks ----------------------------------------------
+
+    def _fock_builder_restricted(self, density):
+        orbitals_orth, occupations = density
+        P_ao = self._density_from_orth(orbitals_orth, occupations)
+        h1 = self.mf.get_hcore()
+        veff = self.mf.get_veff(self.mol, dm=P_ao)
+        E_elec, _ = self.mf.energy_elec(dm=P_ao, h1e=h1, vhf=veff)
+        return (float(E_elec + self.mol.energy_nuc()),
+                self._fock_per_block(h1 + veff))
+
+    def _fock_builder_unrestricted(self, density):
+        orbitals_orth, occupations = density
+        ni = self._n_blocks
+        Pa_ao = self._density_from_orth(orbitals_orth[:ni], occupations[:ni])
+        Pb_ao = self._density_from_orth(orbitals_orth[ni:], occupations[ni:])
+        dm = np.asarray((Pa_ao, Pb_ao))
+        h1 = self.mf.get_hcore()
+        veff = self.mf.get_veff(self.mol, dm=dm)
+        E_elec, _ = self.mf.energy_elec(dm=dm, h1e=h1, vhf=veff)
+        Fa = self._fock_per_block(h1 + veff[0])
+        Fb = self._fock_per_block(h1 + veff[1])
+        return (float(E_elec + self.mol.energy_nuc()), Fa + Fb)
+
+    # --- public API ----------------------------------------------------------
+
+    def initial_fock(self, dm_init=None):
+        if dm_init is None:
+            dm_init = self.mf.get_init_guess()
+        h1 = self.mf.get_hcore()
+        if self._is_uhf:
+            if dm_init.ndim == 2:
+                dm_init = np.asarray((dm_init * 0.5, dm_init * 0.5))
+            veff = self.mf.get_veff(self.mol, dm=dm_init)
+            Fa = self._fock_per_block(h1 + veff[0])
+            Fb = self._fock_per_block(h1 + veff[1])
+            return Fa + Fb
+        veff = self.mf.get_veff(self.mol, dm=dm_init)
+        return self._fock_per_block(h1 + veff)
+
+    def kernel(self, dm_init=None):
+        self.solver.initialize_with_fock(self.initial_fock(dm_init))
+        self.solver.run()
+        self.e_tot = float(self.solver.get_energy(0))
+        return self.e_tot
+
+    def make_rdm1(self):
+        orbitals = self.solver.get_orbitals(0)
+        occupations = self.solver.get_orbital_occupations(0)
+        if self._is_uhf:
+            ni = self._n_blocks
+            Pa = self._density_from_orth(orbitals[:ni], occupations[:ni])
+            Pb = self._density_from_orth(orbitals[ni:], occupations[ni:])
+            return np.asarray((Pa, Pb))
+        return self._density_from_orth(orbitals, occupations)
+
+    @property
+    def block_labels(self):
+        return [_ANG_LABELS.get(l, "l=%d" % l) for l in self._l_values]

--- a/python/openorbital/pyscf/diatomic.py
+++ b/python/openorbital/pyscf/diatomic.py
@@ -1,0 +1,275 @@
+"""Diatomic SCF driver with cylindrical symmetry.
+
+For diatomic molecules orbitals come in groups by ``|m_l|``: ``sigma``
+(``|m|=0``), ``pi`` (``|m|=1``), ``delta`` (``|m|=2``), etc.; ``pi`` and
+``delta`` are two-fold degenerate, so a single radial orbital can hold
+``4`` (restricted) or ``2`` (unrestricted) electrons per radial in
+those shells. OpenOrbitalOptimizer should therefore see one block per
+``(|m|, parity, spin)`` with the ``max_occ`` carrying the
+two-fold-degeneracy of ``|m| > 0`` irreps; symmetric occupation
+splitting across the two components in a partially filled shell falls
+out of the polytope automatically.
+
+PySCF's ``Dooh`` and ``Coov`` symmetry labels the two components of an
+``|m|>0`` irrep with explicit ``x``/``y`` suffixes (``E1gx``/``E1gy``
+for ``pi_g``, ``E2gx``/``E2gy`` for ``delta_g``, ``E3ux``/``E3uy`` for
+``phi_u``, ...). The driver pairs the suffix-twins of every such irrep
+into a single OpenOrbitalOptimizer block with ``max_occ`` doubled.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from openorbital import SCFSolver
+
+from .molecular import _canonical_orthogonalizer
+
+
+# Logical block names for the first few ``|m|>0`` irreps. Anything
+# beyond gamma is reported with its raw ``E_n`` base label.
+_M_TO_LABEL = {1: "pi", 2: "delta", 3: "phi", 4: "gamma"}
+
+
+def _e_irrep_base(name):
+    """Strip a trailing ``x``/``y`` from a PySCF Dooh/Coov irrep name.
+
+    Returns ``(base, suffix)`` if the name is an ``E_n`` component, or
+    ``None`` if it is a one-dimensional ``A``/``B`` irrep.
+    """
+    if len(name) > 1 and name[-1] in ("x", "y") and name[0] == "E":
+        return name[:-1], name[-1]
+    return None
+
+
+def _pair_irreps_for_diatomic(irrep_names, symm_orbs):
+    """Pair the ``x``/``y`` components of each ``E_n`` irrep.
+
+    Returns a list of ``(label, kind, members)`` records describing
+    each OOO block. ``kind == 'sigma'`` -> ``members`` is a single SALC
+    matrix; ``kind == 'degenerate'`` -> ``members`` is a list of two
+    SALC matrices (the ``x`` and ``y`` components), whose radial Fock
+    matrices are identical by symmetry and whose density is
+    half-occupied each.
+    """
+    by_name = dict(zip(irrep_names, symm_orbs))
+
+    used = set()
+    blocks = []
+    for name in irrep_names:
+        if name in used:
+            continue
+        parsed = _e_irrep_base(name)
+        if parsed is None:
+            blocks.append((name, "sigma", by_name[name]))
+            used.add(name)
+            continue
+        base, suffix = parsed
+        partner = base + ("y" if suffix == "x" else "x")
+        if partner in by_name and partner not in used:
+            # Identify the |m| index from the base, e.g. "E1g" -> 1.
+            m_digit = ""
+            for ch in base[1:]:
+                if ch.isdigit():
+                    m_digit += ch
+                else:
+                    break
+            try:
+                m = int(m_digit)
+            except ValueError:
+                m = None
+            parity_suffix = base[1 + len(m_digit):]  # 'g' / 'u' or ''
+            label_root = _M_TO_LABEL.get(m, base)
+            label = label_root + ("_" + parity_suffix if parity_suffix else "")
+            ux, uy = (by_name[name], by_name[partner]) if suffix == "x" \
+                     else (by_name[partner], by_name[name])
+            blocks.append((label, "degenerate", [ux, uy]))
+            used.update((name, partner))
+        else:
+            blocks.append((name, "sigma", by_name[name]))
+            used.add(name)
+    return blocks
+
+
+class OpenOrbitalDiatomicSCF:
+    """Diatomic SCF driver wrapping a PySCF mean-field with cylindrical symmetry.
+
+    The wrapped PySCF mean-field must be built from a molecule whose
+    ``symmetry`` is ``'Dooh'`` or ``'Coov'`` (PySCF handles these
+    through their D2h/C2v subgroups). Each ``pi`` irrep -- whose two
+    D2h/C2v components are mandatorily degenerate by symmetry -- is
+    collapsed into a single OpenOrbitalOptimizer block whose
+    ``max_occ`` is doubled so that the polytope sees one radial channel
+    per ``(pi, parity, spin)``. ``sigma`` irreps remain one OOO block
+    each. ``delta`` and higher ``|m|`` irreps are *not* paired in this
+    draft and would land in whichever D2h irrep they happen to share
+    with ``sigma`` or ``pi``; the driver therefore targets first- and
+    second-row diatomics where ``delta``/``phi`` are unoccupied.
+    """
+
+    def __init__(self,
+                 mf,
+                 linear_dependency_threshold: float = 1e-8):
+        from pyscf.scf import uhf
+
+        self.mf = mf
+        self.mol = mf.mol
+        self._is_uhf = isinstance(mf, uhf.UHF)
+        self._nao = self.mol.nao_nr()
+
+        groupname = getattr(self.mol, "groupname", "")
+        if groupname not in ("Dooh", "Coov"):
+            raise ValueError(
+                "diatomic driver expects mol.symmetry in {'Dooh','Coov'}, "
+                "got groupname=%r" % groupname)
+
+        # Pair the two-component E_n irreps; one-dimensional irreps
+        # stay as-is.
+        blocks = _pair_irreps_for_diatomic(
+            list(self.mol.irrep_name), list(self.mol.symm_orb))
+        self._block_records = blocks  # list of (label, kind, members)
+        self._n_blocks = len(blocks)
+
+        # Per-block canonical orthogonalizer.
+        overlap = mf.get_ovlp()
+        self._T = []  # for sigma: single (nao, n_orth) matrix
+                      # for pi:    list of two (nao, n_orth) matrices (degenerate)
+        for label, kind, members in blocks:
+            if kind == "sigma":
+                U = members
+                S_irrep = U.T @ overlap @ U
+                X = _canonical_orthogonalizer(
+                    S_irrep, linear_dependency_threshold)
+                self._T.append(U @ X)
+            else:  # pi: two components with identical radial overlap
+                Ux, Uy = members
+                Sx = Ux.T @ overlap @ Ux
+                X = _canonical_orthogonalizer(
+                    Sx, linear_dependency_threshold)
+                self._T.append((Ux @ X, Uy @ X))
+
+        # Set up the solver. max_occ is 2 / 1 for sigma, 4 / 2 for pi.
+        block_labels = [b[0] for b in blocks]
+        if self._is_uhf:
+            n_alpha, n_beta = self.mol.nelec
+            max_occ_one = [2.0 if kind == "degenerate" else 1.0
+                           for _, kind, _ in blocks]
+            self.solver = SCFSolver(
+                number_of_blocks_per_particle_type=np.array(
+                    [self._n_blocks, self._n_blocks], dtype=np.uintp),
+                maximum_occupation=np.array(max_occ_one + max_occ_one),
+                number_of_particles=np.array(
+                    [float(n_alpha), float(n_beta)]),
+                fock_builder=self._fock_builder_unrestricted,
+                block_descriptions=[lbl + " alpha" for lbl in block_labels]
+                                 + [lbl + " beta" for lbl in block_labels],
+            )
+        else:
+            n_elec = self.mol.nelectron
+            max_occ = [4.0 if kind == "degenerate" else 2.0
+                       for _, kind, _ in blocks]
+            self.solver = SCFSolver(
+                number_of_blocks_per_particle_type=np.array(
+                    [self._n_blocks], dtype=np.uintp),
+                maximum_occupation=np.array(max_occ),
+                number_of_particles=np.array([float(n_elec)]),
+                fock_builder=self._fock_builder_restricted,
+                block_descriptions=list(block_labels),
+            )
+
+        self.e_tot = None
+
+    # --- helpers --------------------------------------------------------------
+
+    def _density_from_orth(self, orbitals_blocks, occupations_blocks):
+        P_ao = np.zeros((self._nao, self._nao))
+        for record, T_entry, C, n in zip(
+                self._block_records, self._T, orbitals_blocks, occupations_blocks):
+            if C.size == 0:
+                continue
+            label, kind, _ = record
+            if kind == "sigma":
+                C_ao = T_entry @ C
+                P_ao += (C_ao * n) @ C_ao.T
+            else:
+                # Pi: two degenerate components share the same radial
+                # orbital; each carries n/2 of the occupation.
+                Tx, Ty = T_entry
+                Cx_ao = Tx @ C
+                Cy_ao = Ty @ C
+                P_ao += (Cx_ao * (n / 2.0)) @ Cx_ao.T
+                P_ao += (Cy_ao * (n / 2.0)) @ Cy_ao.T
+        return P_ao
+
+    def _fock_per_block(self, F_ao):
+        out = []
+        for record, T_entry in zip(self._block_records, self._T):
+            label, kind, _ = record
+            if kind == "sigma":
+                F = T_entry.T @ F_ao @ T_entry
+            else:
+                Tx, Ty = T_entry
+                # Components are degenerate; average the two for cleanliness.
+                F = 0.5 * (Tx.T @ F_ao @ Tx + Ty.T @ F_ao @ Ty)
+            out.append(np.asfortranarray(F))
+        return out
+
+    # --- Fock-builder callbacks ----------------------------------------------
+
+    def _fock_builder_restricted(self, density):
+        orbitals_orth, occupations = density
+        P_ao = self._density_from_orth(orbitals_orth, occupations)
+        h1 = self.mf.get_hcore()
+        veff = self.mf.get_veff(self.mol, dm=P_ao)
+        E_elec, _ = self.mf.energy_elec(dm=P_ao, h1e=h1, vhf=veff)
+        return (float(E_elec + self.mol.energy_nuc()),
+                self._fock_per_block(h1 + veff))
+
+    def _fock_builder_unrestricted(self, density):
+        orbitals_orth, occupations = density
+        ni = self._n_blocks
+        Pa_ao = self._density_from_orth(orbitals_orth[:ni], occupations[:ni])
+        Pb_ao = self._density_from_orth(orbitals_orth[ni:], occupations[ni:])
+        dm = np.asarray((Pa_ao, Pb_ao))
+        h1 = self.mf.get_hcore()
+        veff = self.mf.get_veff(self.mol, dm=dm)
+        E_elec, _ = self.mf.energy_elec(dm=dm, h1e=h1, vhf=veff)
+        Fa = self._fock_per_block(h1 + veff[0])
+        Fb = self._fock_per_block(h1 + veff[1])
+        return (float(E_elec + self.mol.energy_nuc()), Fa + Fb)
+
+    # --- public API ----------------------------------------------------------
+
+    def initial_fock(self, dm_init=None):
+        if dm_init is None:
+            dm_init = self.mf.get_init_guess()
+        h1 = self.mf.get_hcore()
+        if self._is_uhf:
+            if dm_init.ndim == 2:
+                dm_init = np.asarray((dm_init * 0.5, dm_init * 0.5))
+            veff = self.mf.get_veff(self.mol, dm=dm_init)
+            Fa = self._fock_per_block(h1 + veff[0])
+            Fb = self._fock_per_block(h1 + veff[1])
+            return Fa + Fb
+        veff = self.mf.get_veff(self.mol, dm=dm_init)
+        return self._fock_per_block(h1 + veff)
+
+    def kernel(self, dm_init=None):
+        self.solver.initialize_with_fock(self.initial_fock(dm_init))
+        self.solver.run()
+        self.e_tot = float(self.solver.get_energy(0))
+        return self.e_tot
+
+    def make_rdm1(self):
+        orbitals = self.solver.get_orbitals(0)
+        occupations = self.solver.get_orbital_occupations(0)
+        if self._is_uhf:
+            ni = self._n_blocks
+            Pa = self._density_from_orth(orbitals[:ni], occupations[:ni])
+            Pb = self._density_from_orth(orbitals[ni:], occupations[ni:])
+            return np.asarray((Pa, Pb))
+        return self._density_from_orth(orbitals, occupations)
+
+    @property
+    def block_labels(self):
+        return [label for label, _, _ in self._block_records]

--- a/python/openorbital/pyscf/molecular.py
+++ b/python/openorbital/pyscf/molecular.py
@@ -1,0 +1,224 @@
+"""Molecular SCF driver wrapping PySCF mean-fields.
+
+Provides ``OpenOrbitalSCF``, a thin adapter that uses
+``openorbital.SCFSolver`` for the convergence loop and a PySCF
+mean-field instance for the Fock build. Supports closed-shell (RHF,
+RKS) and unrestricted (UHF, UKS) ground states with and without
+point-group symmetry.
+
+When PySCF's ``mol.symmetry`` is enabled, every irreducible
+representation becomes its own OpenOrbitalOptimizer block, so the
+SCF respects symmetry by construction: orbitals never mix across
+irreps, and the symmetry-mandated degeneracies inside multi-
+dimensional irreps (E, T, ...) come out automatically as degenerate
+eigenvalues of the per-irrep Fock matrix. Without symmetry, the
+driver uses a single block per spin channel.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from openorbital import SCFSolver
+
+
+def _canonical_orthogonalizer(overlap: np.ndarray,
+                              linear_dependency_threshold: float) -> np.ndarray:
+    """Return X with X.T @ overlap @ X = I, dropping linear dependencies."""
+    eigvals, eigvecs = np.linalg.eigh(overlap)
+    keep = eigvals > linear_dependency_threshold
+    return eigvecs[:, keep] * np.power(eigvals[keep], -0.5)
+
+
+def _irrep_decomposition(mol):
+    """List of (irrep_name, U) where U is the AO -> SALC basis transformation
+    for an irreducible representation. Returns a single ("A", identity) entry
+    when ``mol.symmetry`` is off or empty so the rest of the driver can be
+    spelled in terms of a uniform irrep loop."""
+    if getattr(mol, 'symmetry', False) and getattr(mol, 'symm_orb', None):
+        return list(zip(mol.irrep_name, mol.symm_orb))
+    nao = mol.nao_nr()
+    return [("A", np.eye(nao))]
+
+
+class OpenOrbitalSCF:
+    """OpenOrbitalOptimizer-backed SCF driver wrapping a PySCF mean-field.
+
+    Parameters
+    ----------
+    mf : pyscf.scf.hf.SCF
+        A PySCF mean-field instance (RHF, RKS, UHF, UKS, ...). The
+        wrapper does not call ``mf.kernel``; the SCF loop is driven by
+        OpenOrbitalOptimizer with this object only used as a Fock
+        builder. If ``mf.mol.symmetry`` is true, each irrep becomes a
+        separate OpenOrbitalOptimizer block.
+    linear_dependency_threshold : float, optional
+        AO overlap eigenvalues below this threshold are dropped from
+        the orthonormal basis (per irrep). Default ``1e-8``.
+
+    Attributes
+    ----------
+    solver : openorbital.SCFSolver
+        Underlying SCF solver. Configuration knobs
+        (``convergence_threshold``, ``maximum_iterations``,
+        ``optimal_damping_degeneracy_threshold``, ``verbosity``)
+        go through this object.
+    e_tot : float or None
+        Total energy after ``kernel`` has been called.
+    """
+
+    def __init__(self,
+                 mf,
+                 linear_dependency_threshold: float = 1e-8):
+        # Local PySCF import so the rest of openorbital is usable without PySCF.
+        from pyscf.scf import uhf
+
+        self.mf = mf
+        self.mol = mf.mol
+        self._is_uhf = isinstance(mf, uhf.UHF)
+
+        # Per-irrep orthogonalizer T_i: a (nao, n_orth_i) matrix that maps
+        # an orthonormal-irrep coefficient vector back to the AO basis.
+        irreps = _irrep_decomposition(self.mol)
+        overlap = mf.get_ovlp()
+        self._irrep_names = [name for name, _ in irreps]
+        self._T = []
+        for _, U in irreps:
+            S_irrep = U.T @ overlap @ U
+            X = _canonical_orthogonalizer(S_irrep, linear_dependency_threshold)
+            self._T.append(U @ X)
+        self._n_irreps = len(self._T)
+        self._nao = self.mol.nao_nr()
+
+        # Set up SCFSolver: one block per (irrep, spin).
+        if self._is_uhf:
+            n_alpha, n_beta = self.mol.nelec
+            self.solver = SCFSolver(
+                number_of_blocks_per_particle_type=np.array(
+                    [self._n_irreps, self._n_irreps], dtype=np.uintp),
+                maximum_occupation=np.ones(2 * self._n_irreps),
+                number_of_particles=np.array(
+                    [float(n_alpha), float(n_beta)]),
+                fock_builder=self._fock_builder_unrestricted,
+                block_descriptions=[name + " alpha" for name in self._irrep_names]
+                                 + [name + " beta" for name in self._irrep_names],
+            )
+        else:
+            n_elec = self.mol.nelectron
+            self.solver = SCFSolver(
+                number_of_blocks_per_particle_type=np.array(
+                    [self._n_irreps], dtype=np.uintp),
+                maximum_occupation=np.full(self._n_irreps, 2.0),
+                number_of_particles=np.array([float(n_elec)]),
+                fock_builder=self._fock_builder_restricted,
+                block_descriptions=list(self._irrep_names),
+            )
+
+        self.e_tot = None
+
+    # --- basis-change helpers ------------------------------------------------
+
+    def _density_from_irrep_orbitals(self,
+                                     orbitals_blocks,
+                                     occupations_blocks) -> np.ndarray:
+        """Sum per-irrep orth-basis (orbitals, occupations) into an AO density."""
+        P_ao = np.zeros((self._nao, self._nao))
+        for T, C, n in zip(self._T, orbitals_blocks, occupations_blocks):
+            if C.size == 0:
+                continue
+            C_ao = T @ C
+            P_ao += (C_ao * n) @ C_ao.T
+        return P_ao
+
+    def _fock_per_irrep(self, F_ao: np.ndarray):
+        """Project an AO Fock matrix into the orthonormal basis of each irrep."""
+        return [np.asfortranarray(T.T @ F_ao @ T) for T in self._T]
+
+    # --- Fock-builder callbacks ----------------------------------------------
+
+    def _fock_builder_restricted(self, density):
+        orbitals_orth, occupations = density
+        P_ao = self._density_from_irrep_orbitals(orbitals_orth, occupations)
+        h1 = self.mf.get_hcore()
+        veff = self.mf.get_veff(self.mol, dm=P_ao)
+        E_elec, _ = self.mf.energy_elec(dm=P_ao, h1e=h1, vhf=veff)
+        return (float(E_elec + self.mol.energy_nuc()),
+                self._fock_per_irrep(h1 + veff))
+
+    def _fock_builder_unrestricted(self, density):
+        orbitals_orth, occupations = density
+        ni = self._n_irreps
+        Pa_ao = self._density_from_irrep_orbitals(orbitals_orth[:ni],
+                                                  occupations[:ni])
+        Pb_ao = self._density_from_irrep_orbitals(orbitals_orth[ni:],
+                                                  occupations[ni:])
+        dm = np.asarray((Pa_ao, Pb_ao))
+        h1 = self.mf.get_hcore()
+        veff = self.mf.get_veff(self.mol, dm=dm)
+        E_elec, _ = self.mf.energy_elec(dm=dm, h1e=h1, vhf=veff)
+        Fa_blocks = self._fock_per_irrep(h1 + veff[0])
+        Fb_blocks = self._fock_per_irrep(h1 + veff[1])
+        return (float(E_elec + self.mol.energy_nuc()),
+                Fa_blocks + Fb_blocks)
+
+    # --- public API ----------------------------------------------------------
+
+    def initial_fock(self, dm_init=None):
+        """Per-irrep Fock blocks built from ``dm_init`` (PySCF init guess by default)."""
+        if dm_init is None:
+            dm_init = self.mf.get_init_guess()
+        h1 = self.mf.get_hcore()
+        if self._is_uhf:
+            if dm_init.ndim == 2:
+                dm_init = np.asarray((dm_init * 0.5, dm_init * 0.5))
+            veff = self.mf.get_veff(self.mol, dm=dm_init)
+            Fa = self._fock_per_irrep(h1 + veff[0])
+            Fb = self._fock_per_irrep(h1 + veff[1])
+            return Fa + Fb
+        veff = self.mf.get_veff(self.mol, dm=dm_init)
+        return self._fock_per_irrep(h1 + veff)
+
+    def kernel(self, dm_init=None):
+        """Run the SCF and return the total energy."""
+        self.solver.initialize_with_fock(self.initial_fock(dm_init))
+        self.solver.run()
+        self.e_tot = float(self.solver.get_energy(0))
+        return self.e_tot
+
+    # --- post-SCF accessors --------------------------------------------------
+
+    def make_rdm1(self):
+        """AO-basis density matrix(es) of the converged state."""
+        orbitals = self.solver.get_orbitals(0)
+        occupations = self.solver.get_orbital_occupations(0)
+        if self._is_uhf:
+            ni = self._n_irreps
+            Pa = self._density_from_irrep_orbitals(orbitals[:ni],
+                                                    occupations[:ni])
+            Pb = self._density_from_irrep_orbitals(orbitals[ni:],
+                                                    occupations[ni:])
+            return np.asarray((Pa, Pb))
+        return self._density_from_irrep_orbitals(orbitals, occupations)
+
+    def mo_coeff_ao(self):
+        """AO-basis MO coefficients, irrep-block list per spin channel."""
+        orbitals = self.solver.get_orbitals(0)
+        if self._is_uhf:
+            ni = self._n_irreps
+            Ca = [T @ C for T, C in zip(self._T, orbitals[:ni])]
+            Cb = [T @ C for T, C in zip(self._T, orbitals[ni:])]
+            return Ca, Cb
+        return [T @ C for T, C in zip(self._T, orbitals)]
+
+    def mo_occ(self):
+        """Per-irrep occupation arrays, separated by spin for unrestricted."""
+        occupations = self.solver.get_orbital_occupations(0)
+        if self._is_uhf:
+            ni = self._n_irreps
+            return list(occupations[:ni]), list(occupations[ni:])
+        return list(occupations)
+
+    @property
+    def irrep_names(self):
+        """Irrep labels used for each block (one per irrep)."""
+        return list(self._irrep_names)

--- a/python/tests/test_one_electron.py
+++ b/python/tests/test_one_electron.py
@@ -1,0 +1,53 @@
+"""Smoke test: 1-electron SCF in an orthonormal basis.
+
+With no electron-electron interaction the Fock matrix is the (fixed)
+core Hamiltonian and the SCF converges in one iteration to the lowest
+eigenvalue of h. The test validates that the C++ -> Python binding,
+the Fock-builder callback, and the SCF driver all wire together
+correctly without invoking any quantum-chemistry machinery.
+"""
+
+import numpy as np
+import openorbital
+
+
+def test_one_electron_diag():
+    # Four-dimensional orthonormal basis with diagonal core Hamiltonian.
+    h = np.diag(np.array([-1.0, -0.5, 0.25, 1.0]))
+
+    def fock_builder(density):
+        orbitals, occupations = density
+        # 1-electron: F = h, E = tr(h P) = sum_i n_i (C^T h C)_ii
+        C = orbitals[0]
+        n = occupations[0]
+        F = h.copy(order="F")
+        energy = float(np.einsum("i,ki,kj,ji->", n, C, h, C))
+        return energy, [F]
+
+    solver = openorbital.SCFSolver(
+        number_of_blocks_per_particle_type=np.array([1], dtype=np.uintp),
+        maximum_occupation=np.array([2.0]),       # closed-shell s-block
+        number_of_particles=np.array([1.0]),       # one electron
+        fock_builder=fock_builder,
+        block_descriptions=["s"],
+    )
+    solver.verbosity(0)
+    solver.convergence_threshold(1e-10)
+    solver.maximum_iterations(50)
+    solver.initialize_with_fock([h.copy(order="F")])
+    solver.run()
+
+    energy = solver.get_energy(0)
+    occupations = solver.get_orbital_occupations(0)[0]
+    np.testing.assert_allclose(energy, -1.0, atol=1e-9)
+    # Single electron should occupy the lowest orbital exclusively.
+    leading = np.argmax(occupations)
+    np.testing.assert_allclose(occupations[leading], 1.0, atol=1e-9)
+    np.testing.assert_allclose(
+        occupations[np.arange(len(occupations)) != leading], 0.0, atol=1e-9
+    )
+
+
+if __name__ == "__main__":
+    test_one_electron_diag()
+    print("OK")

--- a/python/tests/test_pyscf_atomic.py
+++ b/python/tests/test_pyscf_atomic.py
@@ -1,0 +1,105 @@
+"""Atomic SCF driver tests.
+
+Compares the spherically symmetric ``OpenOrbitalAtomicSCF`` against
+PySCF's reference SCF on cases where the converged ground state is
+itself spherically symmetric, so the two implementations must agree.
+"""
+
+import numpy as np
+import pytest
+
+pyscf = pytest.importorskip("pyscf")
+
+from pyscf import gto, scf  # noqa: E402
+
+from openorbital.pyscf.atomic import OpenOrbitalAtomicSCF
+
+
+def _run_pair(mol, mf_cls, **solver_kwargs):
+    mf_ref = mf_cls(mol)
+    e_ref = mf_ref.kernel()
+    mf_oo_base = mf_cls(mol)
+    oo = OpenOrbitalAtomicSCF(mf_oo_base)
+    oo.solver.verbosity(0)
+    for k, v in solver_kwargs.items():
+        getattr(oo.solver, k)(v)
+    e_oo = oo.kernel()
+    return e_ref, e_oo, oo
+
+
+def test_neon_rhf_cc_pvdz():
+    """Closed-shell Ne in cc-pVDZ: 3 s-radials, 2 p-radials, 1 d-polar
+    -- non-trivial virtual space."""
+    mol = gto.M(atom="Ne 0 0 0", basis="cc-pvdz", verbose=0)
+    e_ref, e_oo, oo = _run_pair(
+        mol, scf.RHF,
+        convergence_threshold=1e-9, maximum_iterations=200,
+    )
+    assert abs(e_ref - e_oo) < 1e-6, "Ne RHF: PySCF=%.10f OO=%.10f" % (e_ref, e_oo)
+    assert oo.block_labels == ["s", "p", "d"]
+
+
+def test_argon_uhf_cc_pvdz():
+    """Closed-shell Ar with UHF in cc-pVDZ."""
+    mol = gto.M(atom="Ar 0 0 0", basis="cc-pvdz", spin=0, verbose=0)
+    e_ref, e_oo, oo = _run_pair(
+        mol, scf.UHF,
+        convergence_threshold=1e-9, maximum_iterations=200,
+    )
+    assert abs(e_ref - e_oo) < 1e-6, "Ar UHF: PySCF=%.10f OO=%.10f" % (e_ref, e_oo)
+
+
+def test_nitrogen_quartet_cc_pvdz():
+    """Open-shell N (2p^3, all-same-spin alpha) in cc-pVDZ.
+
+    The alpha p shell is exactly half-filled with all three magnetic
+    components carrying one electron each; the beta p shell is empty;
+    both spin channels have only integer Aufbau-tied fillings, so the
+    spherically symmetric driver and unconstrained PySCF UHF must
+    converge to the same energy.
+    """
+    mol = gto.M(atom="N 0 0 0", basis="cc-pvdz", spin=3, verbose=0)
+    e_ref, e_oo, oo = _run_pair(
+        mol, scf.UHF,
+        convergence_threshold=1e-9, maximum_iterations=300,
+    )
+    assert abs(e_ref - e_oo) < 1e-5, "N quartet: PySCF=%.10f OO=%.10f" % (e_ref, e_oo)
+
+
+def test_phosphorus_quartet_cc_pvdz():
+    """P 3p^3 in cc-pVDZ (analogue of N quartet, with 3s/3p valence)."""
+    mol = gto.M(atom="P 0 0 0", basis="cc-pvdz", spin=3, verbose=0)
+    e_ref, e_oo, oo = _run_pair(
+        mol, scf.UHF,
+        convergence_threshold=1e-9, maximum_iterations=300,
+    )
+    assert abs(e_ref - e_oo) < 1e-5, "P quartet: PySCF=%.10f OO=%.10f" % (e_ref, e_oo)
+
+
+def test_chromium_septet_cc_pvdz():
+    """Cr (3d^5 4s^1) in cc-pVDZ: 6 valence electrons same-spin alpha.
+
+    Both spin channels still have only integer Aufbau-tied fillings
+    (alpha: full 1s..3p, 4s, and the 5-fold-degenerate 3d; beta: full
+    1s..3p only), so the spherical driver must agree with unconstrained
+    UHF.
+    """
+    mol = gto.M(atom="Cr 0 0 0", basis="cc-pvdz", spin=6, verbose=0)
+    e_ref, e_oo, oo = _run_pair(
+        mol, scf.UHF,
+        convergence_threshold=1e-9, maximum_iterations=300,
+    )
+    assert abs(e_ref - e_oo) < 1e-5, "Cr septet: PySCF=%.10f OO=%.10f" % (e_ref, e_oo)
+
+
+if __name__ == "__main__":
+    test_neon_rhf_cc_pvdz()
+    print("Ne RHF / cc-pvdz          OK")
+    test_argon_uhf_cc_pvdz()
+    print("Ar UHF / cc-pvdz          OK")
+    test_nitrogen_quartet_cc_pvdz()
+    print("N quartet UHF / cc-pvdz   OK")
+    test_phosphorus_quartet_cc_pvdz()
+    print("P quartet UHF / cc-pvdz   OK")
+    test_chromium_septet_cc_pvdz()
+    print("Cr septet UHF / cc-pvdz   OK")

--- a/python/tests/test_pyscf_diatomic.py
+++ b/python/tests/test_pyscf_diatomic.py
@@ -1,0 +1,114 @@
+"""Diatomic SCF driver tests.
+
+Compares the cylindrical-symmetry-respecting ``OpenOrbitalDiatomicSCF``
+against PySCF's reference SCF on diatomics whose ground state has only
+integer Aufbau-tied fillings per spin channel (so the two
+implementations must agree). N2 and CO singlets exercise sigma+pi
+collapsing in Dooh and Coov, respectively; O2 triplet exercises pi_g
+with one alpha electron per component.
+"""
+
+import numpy as np
+import pytest
+
+pyscf = pytest.importorskip("pyscf")
+
+from pyscf import gto, scf  # noqa: E402
+
+from openorbital.pyscf.diatomic import OpenOrbitalDiatomicSCF
+
+
+def _run_pair(mol, mf_cls, **solver_kwargs):
+    mf_ref = mf_cls(mol)
+    e_ref = mf_ref.kernel()
+    mf_oo_base = mf_cls(mol)
+    oo = OpenOrbitalDiatomicSCF(mf_oo_base)
+    oo.solver.verbosity(0)
+    for k, v in solver_kwargs.items():
+        getattr(oo.solver, k)(v)
+    e_oo = oo.kernel()
+    return e_ref, e_oo, oo
+
+
+def test_h2_dooh():
+    """H2 singlet in Dooh: only sigma orbitals are occupied; cc-pVDZ
+    polarization functions produce empty pi blocks that the driver
+    correctly enumerates without affecting the converged energy."""
+    mol = gto.M(
+        atom="H 0 0 0; H 0 0 0.74",
+        basis="cc-pvdz",
+        symmetry="Dooh",
+        verbose=0,
+    )
+    e_ref, e_oo, oo = _run_pair(
+        mol, scf.RHF,
+        convergence_threshold=1e-9, maximum_iterations=200,
+    )
+    assert abs(e_ref - e_oo) < 1e-6, "H2: PySCF=%.10f OO=%.10f" % (e_ref, e_oo)
+    assert "A1g" in oo.block_labels and "A1u" in oo.block_labels
+
+
+def test_n2_singlet_dooh():
+    """N2 singlet in Dooh: full pi_u (4 electrons), empty pi_g."""
+    mol = gto.M(
+        atom="N 0 0 0; N 0 0 1.10",
+        basis="cc-pvdz",
+        symmetry="Dooh",
+        verbose=0,
+    )
+    e_ref, e_oo, oo = _run_pair(
+        mol, scf.RHF,
+        convergence_threshold=1e-9, maximum_iterations=200,
+    )
+    assert abs(e_ref - e_oo) < 1e-5, "N2: PySCF=%.10f OO=%.10f" % (e_ref, e_oo)
+    assert "pi_u" in oo.block_labels
+
+
+def test_o2_triplet_dooh():
+    """O2 triplet: pi_g half-filled, both electrons same spin.
+
+    With ms=2 the alpha channel carries both pi_g components singly
+    occupied, the beta channel has empty pi_g; both spin channels have
+    only integer Aufbau-tied fillings, so the driver and unconstrained
+    PySCF UHF must agree.
+    """
+    mol = gto.M(
+        atom="O 0 0 0; O 0 0 1.21",
+        basis="cc-pvdz",
+        spin=2,
+        symmetry="Dooh",
+        verbose=0,
+    )
+    e_ref, e_oo, oo = _run_pair(
+        mol, scf.UHF,
+        convergence_threshold=1e-9, maximum_iterations=200,
+    )
+    assert abs(e_ref - e_oo) < 1e-5, "O2 triplet: PySCF=%.10f OO=%.10f" % (e_ref, e_oo)
+    assert "pi_g" in oo.block_labels
+
+
+def test_co_singlet_coov():
+    """CO singlet in Coov: heteronuclear diatomic with pi pair in C2v."""
+    mol = gto.M(
+        atom="C 0 0 0; O 0 0 1.13",
+        basis="cc-pvdz",
+        symmetry="Coov",
+        verbose=0,
+    )
+    e_ref, e_oo, oo = _run_pair(
+        mol, scf.RHF,
+        convergence_threshold=1e-9, maximum_iterations=200,
+    )
+    assert abs(e_ref - e_oo) < 1e-5, "CO: PySCF=%.10f OO=%.10f" % (e_ref, e_oo)
+    assert "pi" in oo.block_labels
+
+
+if __name__ == "__main__":
+    test_h2_dooh()
+    print("H2 RHF / cc-pvdz Dooh         OK")
+    test_n2_singlet_dooh()
+    print("N2 RHF / cc-pvdz Dooh         OK")
+    test_o2_triplet_dooh()
+    print("O2 UHF triplet / cc-pvdz Dooh OK")
+    test_co_singlet_coov()
+    print("CO RHF / cc-pvdz Coov         OK")

--- a/python/tests/test_pyscf_molecular.py
+++ b/python/tests/test_pyscf_molecular.py
@@ -1,0 +1,87 @@
+"""End-to-end test of the PySCF molecular driver.
+
+For each test case we run PySCF's reference SCF, then run the
+``OpenOrbitalSCF`` wrapper with the same mean-field object configured
+identically, and require the two total energies to agree to micro-
+Hartree. The cases cover:
+
+    1. closed-shell RHF on water without symmetry,
+    2. closed-shell RHF on water with C2v symmetry (each irrep is its
+       own OpenOrbitalOptimizer block),
+    3. unrestricted UHF on a triplet methylene without symmetry.
+"""
+
+import numpy as np
+import pytest
+
+pyscf = pytest.importorskip("pyscf")
+
+from pyscf import gto, scf  # noqa: E402
+
+from openorbital.pyscf import OpenOrbitalSCF
+
+
+def _agrees_with_pyscf(mf, oo_driver, atol=1e-6):
+    pyscf_energy = mf.kernel()
+    oo_energy = oo_driver.kernel()
+    return abs(pyscf_energy - oo_energy) < atol, pyscf_energy, oo_energy
+
+
+def test_rhf_water_no_symmetry():
+    mol = gto.M(
+        atom='O 0 0 0; H 0 0.757 0.587; H 0 -0.757 0.587',
+        basis='sto-3g',
+        symmetry=False,
+        verbose=0,
+    )
+    mf = scf.RHF(mol)
+    oo = OpenOrbitalSCF(mf)
+    oo.solver.verbosity(0)
+    oo.solver.convergence_threshold(1e-8)
+    ok, e_ref, e_oo = _agrees_with_pyscf(mf, oo)
+    assert ok, f"PySCF = {e_ref:.10f}, OO = {e_oo:.10f}"
+    # Single block (no symmetry).
+    assert oo.irrep_names == ["A"]
+
+
+def test_rhf_water_c2v():
+    mol = gto.M(
+        atom='O 0 0 0; H 0 0.757 0.587; H 0 -0.757 0.587',
+        basis='sto-3g',
+        symmetry='C2v',
+        verbose=0,
+    )
+    mf = scf.RHF(mol)
+    oo = OpenOrbitalSCF(mf)
+    oo.solver.verbosity(0)
+    oo.solver.convergence_threshold(1e-8)
+    ok, e_ref, e_oo = _agrees_with_pyscf(mf, oo)
+    assert ok, f"PySCF = {e_ref:.10f}, OO = {e_oo:.10f}"
+    # C2v has four irreps; non-empty ones become OO blocks.
+    assert len(oo.irrep_names) >= 2
+    assert all(name in {"A1", "A2", "B1", "B2"} for name in oo.irrep_names)
+
+
+def test_uhf_triplet_methylene():
+    mol = gto.M(
+        atom='C 0 0 0; H 0 0.99 0.59; H 0 -0.99 0.59',
+        basis='sto-3g',
+        spin=2,
+        symmetry=False,
+        verbose=0,
+    )
+    mf = scf.UHF(mol)
+    oo = OpenOrbitalSCF(mf)
+    oo.solver.verbosity(0)
+    oo.solver.convergence_threshold(1e-8)
+    ok, e_ref, e_oo = _agrees_with_pyscf(mf, oo)
+    assert ok, f"PySCF = {e_ref:.10f}, OO = {e_oo:.10f}"
+
+
+if __name__ == "__main__":
+    test_rhf_water_no_symmetry()
+    print("RHF water (C1)        OK")
+    test_rhf_water_c2v()
+    print("RHF water (C2v)       OK")
+    test_uhf_triplet_methylene()
+    print("UHF CH2 triplet (C1)  OK")


### PR DESCRIPTION
## Summary

Adds a pybind11-based Python binding for `SCFSolver<double, double>` and a PySCF integration layer with three usage-aware drivers, exposed as the `openorbital` package.

* `openorbital.SCFSolver` — direct binding of the C++ solver. NumPy ↔ Armadillo (F-order, by-copy) marshalling for `arma::Mat<double>`, `arma::Col<double>`, and `arma::uvec`; `std::function` Fock-builder callbacks via `pybind11/functional.h`.
* `openorbital.pyscf.OpenOrbitalSCF` — molecular driver. Wraps any PySCF mean-field (`RHF`, `RKS`, `UHF`, `UKS`, …). When `mol.symmetry` is enabled each irrep becomes its own OpenOrbitalOptimizer block; otherwise a single block per spin channel. Canonical orthogonalization per irrep with linear-dependency cutoff.
* `openorbital.pyscf.OpenOrbitalAtomicSCF` — atomic driver. Groups basis shells by angular momentum, averages the AO Fock over the `2l+1` magnetic components per iteration, and runs the solver with `maximum_occupation = 2(2l+1)` (restricted) or `2l+1` (unrestricted). Handles generalized-contraction shells (`n_ctr > 1`).
* `openorbital.pyscf.OpenOrbitalDiatomicSCF` — diatomic driver. Pairs the `x/y` twin components of every `E_n` irrep in `Dooh`/`Coov` (`pi`, `delta`, `phi`, …) into one block with `max_occ` doubled.

The C++ library itself is unchanged — the bindings only call methods that already exist on master.

## Build

Header-only on both sides. Opt-in via the new CMake option:

```bash
cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
      -DOpenOrbitalOptimizer_BUILD_PYTHON=ON \
      -DOpenOrbitalOptimizer_BUILD_TESTING=OFF
cmake --build build
PYTHONPATH=$PWD/build/python python -m pytest python/tests
```

## Test plan

A new CI job, `build-test-python` (linux-gnu), provisions `pybind11`, `numpy`, `pyscf`, and `pytest` via conda-forge, builds with `OpenOrbitalOptimizer_BUILD_PYTHON=ON`, and runs the pytest suite.

The pytest suite (`python/tests`) covers:

- [x] `test_one_electron_diag` — 1-electron diagonal Hamiltonian; smoke-tests the entire binding wiring without quantum chemistry.
- [x] `test_pyscf_molecular.py` — RHF water (no symmetry, C2v), UHF triplet methylene; agreement with PySCF reference to μHa.
- [x] `test_pyscf_atomic.py` — closed-shell Ne, Ar (cc-pVDZ); open-shell N quartet, P quartet, Cr septet where the ground-state has only integer Aufbau-tied fillings per spin channel and the symmetry-respecting driver must match PySCF UHF.
- [x] `test_pyscf_diatomic.py` — H2 / N2 in Dooh, O2 triplet in Dooh, CO in Coov.

All 13 tests pass locally against the rebased branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)