### PR TITLE
defer ODA and symmetrize DIIS error

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 
 <!--
-## vX.Y.0 / 2025-MM-DD (Unreleased)
+## vX.Y.0 / YYYY-MM-DD (Unreleased)
 
 #### Breaking Changes
 
@@ -13,6 +13,43 @@
 
 #### Misc.
 -->
+
+
+## v0.3.0 / 2026-MM-DD (Unreleased)
+
+#### Breaking Changes
+
+#### New Features
+* [\#34](https://github.com/SusiLehtola/OpenOrbitalOptimizer/pull/34) Add Python interface!
+  This covers the most common `SCFSolver<double, double>` case; others added upon request.
+* [\#34](https://github.com/SusiLehtola/OpenOrbitalOptimizer/pull/34) Add a PySCF integration layer
+  with three usage-aware drivers, exposed as the `openorbital` package.
+* [\#35](https://github.com/SusiLehtola/OpenOrbitalOptimizer/pull/35) Add option `oda_restart_steps`
+  to set the number of steps with no DIIS energy improvement after which to use ODA independently of
+  DIIS history length. Previously used `maximum_history_length`/2
+
+#### Enhancements
+
+* [\#35](https://github.com/SusiLehtola/OpenOrbitalOptimizer/pull/35) Explicitly symmetrize matices
+  for DIIS error calculation to avoid numerical issues.
+
+#### Bug Fixes
+* Fix four correctness bugs in SCF solver and CG optimizer
+  - get_energy: bounds check used > instead of >=, allowing out-of-bounds access when
+    `ihist == orbital_history_.size()`.
+  - matricise(vec, dim): the per-block offset was never advanced, so every block read from offset 0
+    of the input vector.
+  - steepest_descent line search: the "decrease step" branch used std::max, which actually grew the
+    step whenever the parabolic prediction was larger than step/20, stalling the search.
+  - CG Polak-Ribière: divided by dot(g_prev, g_prev) without guarding against a zero previous gradient,
+    propagating NaN into the search direction. Fall back to steepest descent in that case.
+
+#### Misc.
+* [\#30](https://github.com/SusiLehtola/OpenOrbitalOptimizer/pull/30) `max(idx)` has been deprecated
+  in Armadillo in favor of `index_max()` so switching to the new syntax.
+* [\#36](https://github.com/SusiLehtola/OpenOrbitalOptimizer/pull/36) Use modern FindPython with pybind11 module.
+* Added a `CLAUDE.md` file to aid agents.
+
 
 
 ## v0.2.0 / 2025-08-12

--- a/openorbitaloptimizer/scfsolver.hpp
+++ b/openorbitaloptimizer/scfsolver.hpp
@@ -322,9 +322,8 @@ namespace OpenOrbitalOptimizer {
       // them and compute commutator to avoid symmetry-related numerical issues.
       arma::Mat<Torb> F_sym = 0.5 * (F + F.t());
       arma::Mat<Torb> P_sym = 0.5 * (P + P.t());
-      arma::Mat<Torb> FP = F_sym * P_sym;
       arma::Mat<Torb> PF = P_sym * F_sym;
-      arma::Mat<Torb> commutator = FP - PF;
+      arma::Mat<Torb> commutator = PF - PF.t();
 
       // To make the L^infty error independent of the underlying basis
       // set, we project the residual into the best orbitals we have

--- a/openorbitaloptimizer/scfsolver.hpp
+++ b/openorbitaloptimizer/scfsolver.hpp
@@ -132,6 +132,8 @@ namespace OpenOrbitalOptimizer {
     Tbase density_restart_factor_ = 1e-4;
     /// History length
     int maximum_history_length_ = 10;
+    /// Steps with no DIIS energy improvement after which to use ODA. Previously maximum_history_length_/2
+    int oda_restart_steps_ = 5;
     /// Convergence threshold for orbital gradient
     Tbase convergence_threshold_ = 1e-7;
     /// Norm to use by default: root-mean-square error
@@ -1837,6 +1839,16 @@ namespace OpenOrbitalOptimizer {
       maximum_history_length_ = maximum_history_length;
     }
 
+    /// Get oda_restart_steps
+    int oda_restart_steps() const {
+      return oda_restart_steps_;
+    }
+
+    /// Set oda_restart_steps
+    void oda_restart_steps(int oda_restart_steps) {
+      oda_restart_steps_ = oda_restart_steps;
+    }
+
     /// Add entry to history, return value is True if energy was lowered
     bool add_entry(const DensityMatrix<Torb, Tbase> & density) {
       // Compute the Fock matrix
@@ -2076,8 +2088,8 @@ namespace OpenOrbitalOptimizer {
         }
 
         if(noda_steps == 0) {
-          if(failed_iterations >= maximum_history_length_) {
-            // Run the same number of steps using ODA
+          if(failed_iterations >= oda_restart_steps()) {
+            // Run ODA for half the history length
             noda_steps = maximum_history_length_/2;
             if(verbosity_>=5) {
               printf("Switching to optimal damping for next iterations\n");

--- a/openorbitaloptimizer/scfsolver.hpp
+++ b/openorbitaloptimizer/scfsolver.hpp
@@ -323,7 +323,8 @@ namespace OpenOrbitalOptimizer {
       arma::Mat<Torb> F_sym = 0.5 * (F + F.t());
       arma::Mat<Torb> P_sym = 0.5 * (P + P.t());
       arma::Mat<Torb> PF = P_sym * F_sym;
-      arma::Mat<Torb> commutator = PF - PF.t();
+      arma::Mat<Torb> FP = F_sym * P_sym;
+      arma::Mat<Torb> commutator = PF - FP;
 
       // To make the L^infty error independent of the underlying basis
       // set, we project the residual into the best orbitals we have

--- a/openorbitaloptimizer/scfsolver.hpp
+++ b/openorbitaloptimizer/scfsolver.hpp
@@ -315,14 +315,20 @@ namespace OpenOrbitalOptimizer {
       // Error is measured by FPS-SPF = FP - PF, since we have a unit metric.
       auto F = get_fock_matrix_block(ihist, iblock);
       auto P = get_density_matrix_block(ihist, iblock);
-      arma::Mat<Torb> PF = P*F;
-      PF -= arma::trans(PF);
+
+      // Though F and P should be symmetric by construction, explicitly symmetrize
+      // them and compute commutator to avoid symmetry-related numerical issues.
+      arma::Mat<Torb> F_sym = 0.5 * (F + F.t());
+      arma::Mat<Torb> P_sym = 0.5 * (P + P.t());
+      arma::Mat<Torb> FP = F_sym * P_sym;
+      arma::Mat<Torb> PF = P_sym * F_sym;
+      arma::Mat<Torb> commutator = FP - PF;
 
       // To make the L^infty error independent of the underlying basis
       // set, we project the residual into the best orbitals we have
       auto C = get_orbital_block(0, iblock);
-      PF = C.t() * PF * C;
-      return PF;
+      commutator = C.t() * commutator * C;
+      return commutator;
     }
 
     /// Compute DIIS residual
@@ -2070,7 +2076,7 @@ namespace OpenOrbitalOptimizer {
         }
 
         if(noda_steps == 0) {
-          if(failed_iterations >= maximum_history_length_/2) {
+          if(failed_iterations >= maximum_history_length_) {
             // Run the same number of steps using ODA
             noda_steps = maximum_history_length_/2;
             if(verbosity_>=5) {


### PR DESCRIPTION
I've been working on Psi4 and OOO together to help its convergence performance. Psi4 counterpart PR is https://github.com/psi4/psi4/pull/3392 . Background is OOO+Psi4 was having problems with tight convergence beyond about 1e-7. The overwhelmingly major fix is compute an AO basis DIIS error in Psi4 and use that in the has-scf-converged? callback fn in Psi4, rather than the OOO-computed DIIS error. According to AI analysis, OOO computing the DIIS error in the orthogonal/MO basis as `C^T * [F,P] * C` is hitting machine precision causing premature convergence stalling, whereas the AO-basis error FDS–SDF keeps providing a signal allowing the SCF to improve. That, of course, is implemented psi-side, and I've been able to remove special relaxed convcrit for 200+ tests.

Back to changes here, a common remaining does-not-converge pattern is DIIS iterations are going down nicely and past the dE=0 limit, but once it hits 5 such iterations of such (half of the DIIS history length), OOO switches to ODA, which doesn't improve and runs out the remaining tens of iterations. So one of the changes here is to give DIIS a little more time (full DIIS history length) to reach convergence before ODA tries to kick in, esp. as ODA is intended for very early iterations or big course corrections. This should be a separate keyword, I'd think. Do you want a separate one for the `if` trigger and another for the length of course correction (noda_steps)? Previously hist/2 and hist/2 for both. I've been using hist and hist/2 .

The symmetrization corrections in diis_residual were early leads for allowing tight convergence. They weren't the ultimate sol'n (even w/o the `C` projection), but when I tried to remove them, an extra dozen tests failed, not so much on convergence as matching reference values and arrays. So I figured I'd mention them.

Does all this sound about right, and which parts do you want from this?