### PR TITLE
drop two arma:: mentions in dead comments

### DIFF
--- a/openorbitaloptimizer/scfsolver.hpp
+++ b/openorbitaloptimizer/scfsolver.hpp
@@ -195,8 +195,8 @@ namespace OpenOrbitalOptimizer {
       return std::get<1>(orbital_history_[ihist]).second[iblock];
     }
 
-    /// Vectorise a single Torb matrix to a real Tbase vector. For complex
-    /// Torb, stack real-then-imag parts (matches arma::vectorise + split).
+    /// Vectorise a single Torb matrix to a real Tbase vector. For
+    /// complex Torb, stack the real and imaginary parts.
     Vector<Tbase> vectorise(const Matrix<Torb> & mat) const {
       return vectorise_real_imag(mat);
     }
@@ -534,22 +534,6 @@ namespace OpenOrbitalOptimizer {
           }
         }
 
-        /*
-        // Rotate search directions. Generate a random ordering of the columns
-        IndexVector randperm(arma::randperm(search_directions.cols()));
-        search_directions=search_directions.cols(randperm);
-        // Mix the vectors together
-        for(size_t i=0;i<search_directions.cols();i++)
-          for(size_t j=0;j<i;j++) {
-            Vector<Tbase> randu(1);
-            randu.randu();
-
-            Vector<Tbase> newi = (1-randu(0))*search_directions.col(i) + randu(0)*search_directions.col(j);
-            Vector<Tbase> newj = (1-randu(0))*search_directions.col(j) + randu(0)*search_directions.col(i);
-            search_directions.col(i) = newi;
-            search_directions.col(j) = newj;
-          }
-        */
       }
 
       // Handle the edge case where the last matrix has zero norm


### PR DESCRIPTION
## Summary

Follow-up cleanup: the two remaining \`arma::\` references reported by \`grep\` in \`openorbitaloptimizer/scfsolver.hpp\` after PR #38 were both inside comments that the compiler never sees:

- A commented-out alternative search-direction-shuffle block in \`minimal_error_sampling_algorithm_weights\` (used \`arma::randperm\` + \`arma::Col::randu\`).
- A docstring parenthetical on \`vectorise()\` mentioning the old \`arma::vectorise + split\` semantics.

Neither was reachable; both were misleading \`grep\` into reporting that the port was incomplete. Delete the dead code and rephrase the docstring in Eigen terms.

## Test plan

- \`grep -c 'arma::' openorbitaloptimizer/scfsolver.hpp\` → 0.
- ctest 8/8 pass locally; no behaviour change.