### PR TITLE
restore <Torb, Tbase> signature, add auto-loading Armadillo shim

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,6 +72,7 @@ jobs:
           - ninja
           - cxx-compiler
           - eigen
+          - armadillo  # optional, for the armadillo_compat shim test target
           - libxc-c
           - nlohmann_json
           - integratorxx

--- a/openorbitaloptimizer/armadillo_compat.hpp
+++ b/openorbitaloptimizer/armadillo_compat.hpp
@@ -136,13 +136,7 @@ namespace Armadillo {
 
   template <class Torb, class Tbase>
   class SCFSolver {
-    static_assert(std::is_same_v<Torb, Tbase> ||
-                  std::is_same_v<Torb, std::complex<Tbase>>,
-                  "Legacy SCFSolver<Torb, Tbase> requires Torb to be "
-                  "either Tbase or std::complex<Tbase>.");
-    static constexpr bool IsComplex_ = std::is_same_v<Torb, std::complex<Tbase>>;
-
-    using EigenSolver = OpenOrbitalOptimizer::SCFSolver<Tbase, IsComplex_>;
+    using EigenSolver = OpenOrbitalOptimizer::SCFSolver<Torb, Tbase>;
     using EigenDM = OpenOrbitalOptimizer::DensityMatrix<Torb, Tbase>;
     using EigenFR = OpenOrbitalOptimizer::FockBuilderReturn<Torb, Tbase>;
 

--- a/openorbitaloptimizer/armadillo_compat.hpp
+++ b/openorbitaloptimizer/armadillo_compat.hpp
@@ -1,0 +1,263 @@
+/*
+ *                This Source Code Form is subject to the
+ *                terms of the Mozilla Public License, v. 2.0.
+ *                If a copy of the MPL was not distributed
+ *                with this file, You can obtain one at
+ *                http://mozilla.org/MPL/2.0/.
+ *
+ *           Copyright (c) 2026 Susi Lehtola
+ */
+
+/// Opt-in compatibility shim that exposes the pre-Eigen public API:
+///
+///   OpenOrbitalOptimizer::Armadillo::SCFSolver<Torb, Tbase>
+///
+/// with all containers Armadillo-typed (arma::Mat, arma::Col, arma::uvec,
+/// etc.). Internally wraps the new Eigen-based
+/// OpenOrbitalOptimizer::SCFSolver<Tbase, IsComplex>, with Armadillo<->
+/// Eigen conversion at the SCFSolver boundary. The conversions are
+/// memcpy-cost (column-major to column-major) and the Fock-builder
+/// callback is bridged transparently.
+///
+/// Including this header pulls in <armadillo>. The core library itself
+/// remains Armadillo-free; only consumers who include this header pay the
+/// Armadillo dependency. Only the four legacy scalar pairs are supported:
+/// (float,float), (double,double), (std::complex<float>,float),
+/// (std::complex<double>,double).
+
+#ifndef OPENORBITALOPTIMIZER_ARMADILLO_COMPAT_HPP
+#define OPENORBITALOPTIMIZER_ARMADILLO_COMPAT_HPP
+
+#include "scfsolver.hpp"
+
+#include <armadillo>
+
+#include <complex>
+#include <functional>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace OpenOrbitalOptimizer {
+namespace Armadillo {
+
+  // ---- Armadillo <-> Eigen conversion helpers ------------------------
+
+  template <class T>
+  inline OpenOrbitalOptimizer::Matrix<T> to_eigen(const arma::Mat<T> & A) {
+    return Eigen::Map<const OpenOrbitalOptimizer::Matrix<T>>(
+        A.memptr(), A.n_rows, A.n_cols);
+  }
+
+  template <class T>
+  inline OpenOrbitalOptimizer::Vector<T> to_eigen(const arma::Col<T> & v) {
+    return Eigen::Map<const OpenOrbitalOptimizer::Vector<T>>(
+        v.memptr(), v.n_elem);
+  }
+
+  inline OpenOrbitalOptimizer::IndexVector to_eigen(const arma::uvec & v) {
+    OpenOrbitalOptimizer::IndexVector out(v.n_elem);
+    for (arma::uword i = 0; i < v.n_elem; ++i)
+      out[static_cast<OpenOrbitalOptimizer::Index>(i)] =
+          static_cast<OpenOrbitalOptimizer::Index>(v[i]);
+    return out;
+  }
+
+  template <class T>
+  inline arma::Mat<T> to_arma(const OpenOrbitalOptimizer::Matrix<T> & E) {
+    return arma::Mat<T>(E.data(), E.rows(), E.cols());
+  }
+
+  template <class T>
+  inline arma::Col<T> to_arma(const OpenOrbitalOptimizer::Vector<T> & v) {
+    return arma::Col<T>(v.data(), v.size());
+  }
+
+  template <class T>
+  inline std::vector<OpenOrbitalOptimizer::Matrix<T>>
+  to_eigen(const std::vector<arma::Mat<T>> & v) {
+    std::vector<OpenOrbitalOptimizer::Matrix<T>> out;
+    out.reserve(v.size());
+    for (const auto & m : v) out.push_back(to_eigen(m));
+    return out;
+  }
+
+  template <class T>
+  inline std::vector<OpenOrbitalOptimizer::Vector<T>>
+  to_eigen(const std::vector<arma::Col<T>> & v) {
+    std::vector<OpenOrbitalOptimizer::Vector<T>> out;
+    out.reserve(v.size());
+    for (const auto & c : v) out.push_back(to_eigen(c));
+    return out;
+  }
+
+  template <class T>
+  inline std::vector<arma::Mat<T>>
+  to_arma(const std::vector<OpenOrbitalOptimizer::Matrix<T>> & v) {
+    std::vector<arma::Mat<T>> out;
+    out.reserve(v.size());
+    for (const auto & e : v) out.push_back(to_arma(e));
+    return out;
+  }
+
+  template <class T>
+  inline std::vector<arma::Col<T>>
+  to_arma(const std::vector<OpenOrbitalOptimizer::Vector<T>> & v) {
+    std::vector<arma::Col<T>> out;
+    out.reserve(v.size());
+    for (const auto & e : v) out.push_back(to_arma(e));
+    return out;
+  }
+
+  // ---- Legacy container typedefs (Armadillo-shaped) ------------------
+
+  template <class T> using OrbitalBlock = arma::Mat<T>;
+  template <class T> using Orbitals = std::vector<OrbitalBlock<T>>;
+  template <class T> using OrbitalGradientBlock = arma::Mat<T>;
+  template <class T> using OrbitalGradients = std::vector<OrbitalGradientBlock<T>>;
+  template <class T> using DiagonalOrbitalHessianBlock = arma::Mat<T>;
+  template <class T> using DiagonalOrbitalHessians = std::vector<DiagonalOrbitalHessianBlock<T>>;
+  template <class T> using OrbitalBlockOccupations = arma::Col<T>;
+  template <class T> using OrbitalOccupations = std::vector<OrbitalBlockOccupations<T>>;
+  template <class Torb, class Tbase>
+  using DensityMatrix = std::pair<Orbitals<Torb>, OrbitalOccupations<Tbase>>;
+  template <class T> using OrbitalEnergies = std::vector<arma::Col<T>>;
+  template <class T> using FockMatrixBlock = arma::Mat<T>;
+  template <class T> using FockMatrix = std::vector<FockMatrixBlock<T>>;
+  template <class Torb, class Tbase>
+  using DiagonalizedFockMatrix = std::pair<Orbitals<Torb>, OrbitalEnergies<Tbase>>;
+  template <class Torb, class Tbase>
+  using FockBuilderReturn = std::pair<Tbase, FockMatrix<Torb>>;
+  template <class Torb, class Tbase>
+  using FockBuilder = std::function<FockBuilderReturn<Torb, Tbase>(const DensityMatrix<Torb, Tbase> &)>;
+  using OrbitalRotation = std::tuple<size_t, arma::uword, arma::uword>;
+
+  // ---- Legacy SCFSolver<Torb, Tbase> wrapper -------------------------
+
+  template <class Torb, class Tbase>
+  class SCFSolver {
+    static_assert(std::is_same_v<Torb, Tbase> ||
+                  std::is_same_v<Torb, std::complex<Tbase>>,
+                  "Legacy SCFSolver<Torb, Tbase> requires Torb to be "
+                  "either Tbase or std::complex<Tbase>.");
+    static constexpr bool IsComplex_ = std::is_same_v<Torb, std::complex<Tbase>>;
+
+    using EigenSolver = OpenOrbitalOptimizer::SCFSolver<Tbase, IsComplex_>;
+    using EigenDM = OpenOrbitalOptimizer::DensityMatrix<Torb, Tbase>;
+    using EigenFR = OpenOrbitalOptimizer::FockBuilderReturn<Torb, Tbase>;
+
+    /// User-supplied Armadillo-typed Fock builder, kept alive so the
+    /// bridging callback below can call it on every Fock evaluation.
+    FockBuilder<Torb, Tbase> arma_fock_builder_;
+    /// Underlying Eigen-based solver. Constructed second so that the
+    /// bridging lambda captured below can already see arma_fock_builder_.
+    EigenSolver impl_;
+
+  public:
+    SCFSolver(const arma::uvec & number_of_blocks_per_particle_type,
+              const arma::Col<Tbase> & maximum_occupation,
+              const arma::Col<Tbase> & number_of_particles,
+              const FockBuilder<Torb, Tbase> & fock_builder,
+              const std::vector<std::string> & block_descriptions)
+      : arma_fock_builder_(fock_builder),
+        impl_(to_eigen(number_of_blocks_per_particle_type),
+              to_eigen(maximum_occupation),
+              to_eigen(number_of_particles),
+              [this](const EigenDM & dm) -> EigenFR {
+                DensityMatrix<Torb, Tbase> arma_dm{
+                    to_arma(dm.first),
+                    to_arma(dm.second)};
+                FockBuilderReturn<Torb, Tbase> arma_ret = arma_fock_builder_(arma_dm);
+                return std::make_pair(arma_ret.first, to_eigen(arma_ret.second));
+              },
+              block_descriptions) {}
+
+    // ---- Pass-through configuration ---------------------------------
+
+    void verbosity(int v)                        { impl_.verbosity(v); }
+    int  verbosity() const                       { return impl_.verbosity(); }
+    void convergence_threshold(Tbase t)          { impl_.convergence_threshold(t); }
+    Tbase convergence_threshold() const          { return impl_.convergence_threshold(); }
+    void maximum_iterations(size_t n)            { impl_.maximum_iterations(n); }
+    size_t maximum_iterations() const            { return impl_.maximum_iterations(); }
+    bool frozen_occupations() const              { return impl_.frozen_occupations(); }
+    void frozen_occupations(bool b)              { impl_.frozen_occupations(b); }
+    void error_norm(const std::string & n)       { impl_.error_norm(n); }
+
+    void diis_epsilon(Tbase e)                   { impl_.diis_epsilon(e); }
+    Tbase diis_epsilon() const                   { return impl_.diis_epsilon(); }
+    void diis_threshold(Tbase e)                 { impl_.diis_threshold(e); }
+    Tbase diis_threshold() const                 { return impl_.diis_threshold(); }
+    void diis_diagonal_damping(Tbase e)          { impl_.diis_diagonal_damping(e); }
+    Tbase diis_diagonal_damping() const          { return impl_.diis_diagonal_damping(); }
+    void diis_restart_factor(Tbase e)            { impl_.diis_restart_factor(e); }
+    Tbase diis_restart_factor() const            { return impl_.diis_restart_factor(); }
+    void optimal_damping_threshold(Tbase e)      { impl_.optimal_damping_threshold(e); }
+    Tbase optimal_damping_threshold() const      { return impl_.optimal_damping_threshold(); }
+    void maximum_history_length(int n)           { impl_.maximum_history_length(n); }
+    int  maximum_history_length() const          { return impl_.maximum_history_length(); }
+    void oda_restart_steps(int n)                { impl_.oda_restart_steps(n); }
+    int  oda_restart_steps() const               { return impl_.oda_restart_steps(); }
+
+    void fixed_number_of_particles_per_block(const arma::Col<Tbase> & v) {
+      impl_.fixed_number_of_particles_per_block(to_eigen(v));
+    }
+
+    // ---- Initialisation ---------------------------------------------
+
+    void initialize_with_fock(const FockMatrix<Torb> & fock_guess) {
+      impl_.initialize_with_fock(to_eigen(fock_guess));
+    }
+    void initialize_with_orbitals(const Orbitals<Torb> & orbitals,
+                                   const OrbitalOccupations<Tbase> & occupations) {
+      impl_.initialize_with_orbitals(to_eigen(orbitals), to_eigen(occupations));
+    }
+
+    // ---- Driving the SCF --------------------------------------------
+
+    void run()                                   { impl_.run(); }
+    void run_optimal_damping()                   { impl_.run_optimal_damping(); }
+    bool converged() const                       { return impl_.converged(); }
+    void brute_force_search_for_lowest_configuration() {
+      impl_.brute_force_search_for_lowest_configuration();
+    }
+
+    // ---- Solution retrieval -----------------------------------------
+
+    DensityMatrix<Torb, Tbase> get_solution(size_t ihist = 0) const {
+      auto eigen_dm = impl_.get_solution(ihist);
+      return {to_arma(eigen_dm.first), to_arma(eigen_dm.second)};
+    }
+    Orbitals<Torb> get_orbitals(size_t ihist = 0) const {
+      return to_arma(impl_.get_orbitals(ihist));
+    }
+    OrbitalOccupations<Tbase> get_orbital_occupations(size_t ihist = 0) const {
+      return to_arma(impl_.get_orbital_occupations(ihist));
+    }
+    FockBuilderReturn<Torb, Tbase> get_fock_build(size_t ihist = 0) const {
+      auto eigen_fb = impl_.get_fock_build(ihist);
+      return {eigen_fb.first, to_arma(eigen_fb.second)};
+    }
+    FockMatrix<Torb> get_fock_matrix(size_t ihist = 0) const {
+      return to_arma(impl_.get_fock_matrix(ihist));
+    }
+    Tbase get_energy(size_t ihist = 0) const     { return impl_.get_energy(ihist); }
+
+    // ---- Diagnostics & utilities ------------------------------------
+
+    void print_history() const                   { impl_.print_history(); }
+    void reset_history()                         { impl_.reset_history(); }
+
+    DiagonalizedFockMatrix<Torb, Tbase> compute_orbitals(const FockMatrix<Torb> & fock) const {
+      auto eigen_diag = impl_.compute_orbitals(to_eigen(fock));
+      return {to_arma(eigen_diag.first), to_arma(eigen_diag.second)};
+    }
+    OrbitalOccupations<Tbase> update_occupations(const OrbitalEnergies<Tbase> & orbital_energies) const {
+      return to_arma(impl_.update_occupations(to_eigen(orbital_energies)));
+    }
+  };
+
+} // namespace Armadillo
+} // namespace OpenOrbitalOptimizer
+
+#endif

--- a/openorbitaloptimizer/scfsolver.hpp
+++ b/openorbitaloptimizer/scfsolver.hpp
@@ -22,14 +22,15 @@
 
 namespace OpenOrbitalOptimizer {
 
-  /// SCF solver class. Templated on the real type Tbase (e.g. float,
-  /// double, __float128) and a boolean IsComplex selecting between real
-  /// and complex orbital coefficients. The orbital scalar type Torb is
-  /// std::conditional_t<IsComplex, std::complex<Tbase>, Tbase>.
-  template<typename Tbase, bool IsComplex> class SCFSolver {
-  public:
-    /// Orbital scalar type derived from <Tbase, IsComplex>.
-    using Torb = OrbitalScalar<Tbase, IsComplex>;
+  /// SCF solver class. Templated on the orbital scalar type Torb (real
+  /// or complex) and the real type Tbase (e.g. float, double,
+  /// __float128). Torb must be either Tbase or std::complex<Tbase>; any
+  /// other combination is rejected at compile time.
+  template<typename Torb, typename Tbase> class SCFSolver {
+    static_assert(std::is_same_v<Torb, Tbase> ||
+                  std::is_same_v<Torb, std::complex<Tbase>>,
+                  "SCFSolver<Torb, Tbase>: Torb must be either Tbase or "
+                  "std::complex<Tbase>");
   private:
     /* Input data section */
     /// The number of orbital blocks per particle type (length ntypes)
@@ -2439,3 +2440,12 @@ namespace OpenOrbitalOptimizer {
     }
   };
 }
+
+// If <armadillo> is available in the include path, automatically pull in
+// the Armadillo compatibility shim so downstream code that still uses
+// arma::-typed inputs/outputs gets OpenOrbitalOptimizer::Armadillo::SCFSolver
+// without an extra include. Consumers who do not want Armadillo simply do
+// not have it in their include path; this is a no-op then.
+#if __has_include(<armadillo>)
+#include "armadillo_compat.hpp"
+#endif

--- a/python/_ext.cpp
+++ b/python/_ext.cpp
@@ -20,12 +20,12 @@ PYBIND11_MODULE(_ext, m) {
   m.doc() = "OpenOrbitalOptimizer Python bindings";
 
   using namespace OpenOrbitalOptimizer;
-  using Solver = SCFSolver<double, false>;
+  using Solver = SCFSolver<double, double>;
 
   py::class_<Solver>(m, "SCFSolver",
       "SCF solver supporting fractional/degenerate occupations through\n"
       "skeleton density matrices and bi-level ODA + preconditioned CG\n"
-      "minimization. Bound for SCFSolver<double, IsComplex=false>:\n"
+      "minimization. Bound for SCFSolver<double, double>:\n"
       "double-precision real orbital coefficients and energies.")
     .def(py::init<IndexVector, Vector<double>, Vector<double>,
                   FockBuilder<double, double>, std::vector<std::string>>(),

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -86,6 +86,30 @@ set_tests_properties(
     COMMAND "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target openorbopt-instantiation-double-complex
   )
 
+  # Armadillo compatibility shim (opt-in for downstream callers that still
+  # carry arma::-shaped data). The core library does not link Armadillo, so
+  # this target is only added when an Armadillo installation is present.
+  find_package(Armadillo CONFIG QUIET)
+  if (Armadillo_FOUND AND TARGET armadillo)
+    add_executable(
+      openorbopt-armadillo-compat
+      EXCLUDE_FROM_ALL
+      armadillo_compat.cpp
+    )
+    target_link_libraries(
+      openorbopt-armadillo-compat
+      PRIVATE
+      ${ooo}::OpenOrbitalOptimizer
+      armadillo
+    )
+    add_test(  # Test #7
+      NAME openorbopt/armadillo-compat/build
+      COMMAND "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target openorbopt-armadillo-compat
+    )
+  else()
+    message(STATUS "Skipping Armadillo compatibility shim test: Armadillo not found")
+  endif()
+
   # Quad-precision (_Float128) instantiations. Require both the
   # _Float128 language type (GCC extension, plus a recent libstdc++ that
   # has the std::sqrt/... overloads behind __cpp_lib_extended_float) and

--- a/tests/armadillo_compat.cpp
+++ b/tests/armadillo_compat.cpp
@@ -1,0 +1,12 @@
+#include <openorbitaloptimizer/armadillo_compat.hpp>
+
+// Instantiate the legacy Armadillo-typed wrapper for all four scalar
+// pairs it supports. This is a compile-only sanity check.
+template class OpenOrbitalOptimizer::Armadillo::SCFSolver<float, float>;
+template class OpenOrbitalOptimizer::Armadillo::SCFSolver<double, double>;
+template class OpenOrbitalOptimizer::Armadillo::SCFSolver<std::complex<float>, float>;
+template class OpenOrbitalOptimizer::Armadillo::SCFSolver<std::complex<double>, double>;
+
+int main(void) {
+  return 0;
+}

--- a/tests/atomtest.cpp
+++ b/tests/atomtest.cpp
@@ -9,7 +9,7 @@
 
 namespace OpenOrbitalOptimizer {
   // Instantiate all types of SCFSolver just to check it compiles
-  template class SCFSolver<double, false>;
+  template class SCFSolver<double, double>;
 
   namespace AtomicSolver {
 
@@ -467,7 +467,7 @@ namespace OpenOrbitalOptimizer {
       return E;
     }
 
-    OpenOrbitalOptimizer::SCFSolver<double, false> restricted_scf(int Z, int Q, int x_func_id, int c_func_id, int Ngrid, double linear_dependency_threshold, double convergence_threshold, const std::vector<std::shared_ptr<const OpenOrbitalOptimizer::AtomicSolver::RadialBasis>> & radial_basis, int verbosity, bool core_excitation) {
+    OpenOrbitalOptimizer::SCFSolver<double, double> restricted_scf(int Z, int Q, int x_func_id, int c_func_id, int Ngrid, double linear_dependency_threshold, double convergence_threshold, const std::vector<std::shared_ptr<const OpenOrbitalOptimizer::AtomicSolver::RadialBasis>> & radial_basis, int verbosity, bool core_excitation) {
       // Form the orthogonal orbital basis
       std::vector<Eigen::MatrixXd> X = form_X(linear_dependency_threshold, radial_basis);
 
@@ -551,7 +551,7 @@ namespace OpenOrbitalOptimizer {
       };
 
       // Initialize SCF solver
-      OpenOrbitalOptimizer::SCFSolver<double, false> scfsolver(
+      OpenOrbitalOptimizer::SCFSolver<double, double> scfsolver(
           number_of_blocks_per_particle_type,
           maximum_occupation,
           number_of_particles,
@@ -580,7 +580,7 @@ namespace OpenOrbitalOptimizer {
       return scfsolver;
     }
 
-    OpenOrbitalOptimizer::SCFSolver<double, false> unrestricted_scf(int Z, int Q, int M, int x_func_id, int c_func_id, int Ngrid, double linear_dependency_threshold, double convergence_threshold, const std::vector<std::shared_ptr<const OpenOrbitalOptimizer::AtomicSolver::RadialBasis>> & radial_basis, int verbosity, bool core_excitation) {
+    OpenOrbitalOptimizer::SCFSolver<double, double> unrestricted_scf(int Z, int Q, int M, int x_func_id, int c_func_id, int Ngrid, double linear_dependency_threshold, double convergence_threshold, const std::vector<std::shared_ptr<const OpenOrbitalOptimizer::AtomicSolver::RadialBasis>> & radial_basis, int verbosity, bool core_excitation) {
       // Form the orthogonal orbital basis
       std::vector<Eigen::MatrixXd> X = form_X(linear_dependency_threshold, radial_basis);
 
@@ -702,7 +702,7 @@ namespace OpenOrbitalOptimizer {
       };
 
       // Initialize SCF solver
-      OpenOrbitalOptimizer::SCFSolver<double, false> scfsolver(
+      OpenOrbitalOptimizer::SCFSolver<double, double> scfsolver(
           number_of_blocks_per_particle_type,
           maximum_occupation,
           number_of_particles,
@@ -731,7 +731,7 @@ namespace OpenOrbitalOptimizer {
       return scfsolver;
     }
 
-    OpenOrbitalOptimizer::SCFSolver<double, false> unrestricted_neo_scf(int Z, int Q, int M, int x_func_id, int c_func_id, int epc_func_id, int Ngrid, double linear_dependency_threshold, double convergence_threshold, const std::vector<std::shared_ptr<const OpenOrbitalOptimizer::AtomicSolver::RadialBasis>> & radial_basis, const std::vector<std::shared_ptr<const OpenOrbitalOptimizer::AtomicSolver::RadialBasis>> & protonic_basis, double proton_mass, int verbosity, bool core_excitation) {
+    OpenOrbitalOptimizer::SCFSolver<double, double> unrestricted_neo_scf(int Z, int Q, int M, int x_func_id, int c_func_id, int epc_func_id, int Ngrid, double linear_dependency_threshold, double convergence_threshold, const std::vector<std::shared_ptr<const OpenOrbitalOptimizer::AtomicSolver::RadialBasis>> & radial_basis, const std::vector<std::shared_ptr<const OpenOrbitalOptimizer::AtomicSolver::RadialBasis>> & protonic_basis, double proton_mass, int verbosity, bool core_excitation) {
       // Form the orthogonal orbital basis
       std::vector<Eigen::MatrixXd> X  = form_X(linear_dependency_threshold, radial_basis);
       std::vector<Eigen::MatrixXd> Xp = form_X(linear_dependency_threshold, protonic_basis);
@@ -875,7 +875,7 @@ namespace OpenOrbitalOptimizer {
       };
 
       // Initialize SCF solver
-      OpenOrbitalOptimizer::SCFSolver<double, false> scfsolver(
+      OpenOrbitalOptimizer::SCFSolver<double, double> scfsolver(
           number_of_blocks_per_particle_type,
           maximum_occupation,
           number_of_particles,

--- a/tests/double_complex.cpp
+++ b/tests/double_complex.cpp
@@ -1,7 +1,7 @@
 #include <openorbitaloptimizer/scfsolver.hpp>
 
 // Instantiate the SCF solver class
-template class OpenOrbitalOptimizer::SCFSolver<double, true>;
+template class OpenOrbitalOptimizer::SCFSolver<std::complex<double>, double>;
 
 int main(void) {
   return 0;

--- a/tests/float_complex.cpp
+++ b/tests/float_complex.cpp
@@ -1,6 +1,6 @@
 #include <openorbitaloptimizer/scfsolver.hpp>
 
-template class OpenOrbitalOptimizer::SCFSolver<float, true>;
+template class OpenOrbitalOptimizer::SCFSolver<std::complex<float>, float>;
 
 int main(void) {
   return 0;

--- a/tests/float_real.cpp
+++ b/tests/float_real.cpp
@@ -1,6 +1,6 @@
 #include <openorbitaloptimizer/scfsolver.hpp>
 
-template class OpenOrbitalOptimizer::SCFSolver<float, false>;
+template class OpenOrbitalOptimizer::SCFSolver<float, float>;
 
 int main(void) {
   return 0;

--- a/tests/quad_complex.cpp
+++ b/tests/quad_complex.cpp
@@ -1,7 +1,7 @@
 #include <openorbitaloptimizer/quad_support.hpp>
 #include <openorbitaloptimizer/scfsolver.hpp>
 
-template class OpenOrbitalOptimizer::SCFSolver<_Float128, true>;
+template class OpenOrbitalOptimizer::SCFSolver<std::complex<_Float128>, _Float128>;
 
 int main(void) {
   return 0;

--- a/tests/quad_real.cpp
+++ b/tests/quad_real.cpp
@@ -1,7 +1,7 @@
 #include <openorbitaloptimizer/quad_support.hpp>
 #include <openorbitaloptimizer/scfsolver.hpp>
 
-template class OpenOrbitalOptimizer::SCFSolver<_Float128, false>;
+template class OpenOrbitalOptimizer::SCFSolver<_Float128, _Float128>;
 
 int main(void) {
   return 0;


### PR DESCRIPTION
## Summary

Restores full backwards compatibility for pre-port downstream callers, in two steps:

1. **Revert the public template signature** of `SCFSolver` from `<Tbase, bool IsComplex>` back to the pre-port `<Torb, Tbase>` (with a `static_assert` that `Torb` must be `Tbase` or `std::complex<Tbase>`). The body is unchanged — it already referenced `Torb` and `Tbase` by name throughout; the `if constexpr` paths use `Eigen::NumTraits<Torb>::IsComplex` which works either way. The six instantiations downstream may want all read literally as the pre-port spelling:

   ```cpp
   SCFSolver<float, float>
   SCFSolver<double, double>
   SCFSolver<std::complex<float>, float>
   SCFSolver<std::complex<double>, double>
   SCFSolver<_Float128, _Float128>                 // new
   SCFSolver<std::complex<_Float128>, _Float128>   // new
   ```

2. **Add an opt-in `openorbitaloptimizer/armadillo_compat.hpp`** providing:
   - `OpenOrbitalOptimizer::Armadillo::SCFSolver<Torb, Tbase>` — wraps the new Eigen-based solver, with `arma::uvec` / `arma::Col` / `arma::Mat` in every signature; bridges Armadillo ↔ Eigen at construction, in `initialize_with_*`, around the user-supplied Fock-builder callback, and on every getter.
   - The legacy container typedefs (`Orbitals<T>`, `OrbitalOccupations<T>`, `FockMatrix<T>`, `DensityMatrix<Torb,Tbase>`, `FockBuilder<Torb,Tbase>`, …) in the `Armadillo` sub-namespace, with `arma::Mat` / `arma::Col` as the underlying storage.
   - Standalone `OpenOrbitalOptimizer::Armadillo::to_eigen()` / `to_arma()` helpers for ad-hoc bridging.

   `scfsolver.hpp` **auto-includes** the shim whenever `<armadillo>` is on the include path (`__has_include`). Consumers who already had Armadillo around (Psi4, etc.) get `Armadillo::SCFSolver` available with no extra `#include`; consumers who never had Armadillo see no change and pay no dependency.

Together, these two changes mean any pre-port code that used `OpenOrbitalOptimizer::SCFSolver<Torb, Tbase>` continues to work with Eigen-typed I/O at the SCFSolver boundary, and any caller that wants to keep arma::-typed I/O just adds the `Armadillo::` namespace qualifier.

## Verification

- 9/9 ctest pass locally (atomtest run1/run2 + 6 instantiation builds + new armadillo-compat target).
- atomtest run1/run2 reproduce `-74.9164866611` / `-74.9722875549` Eh.
- Downstream-style smoke: a translation unit that only does `#include <openorbitaloptimizer/scfsolver.hpp>` can instantiate `OpenOrbitalOptimizer::SCFSolver<double, double>` AND `OpenOrbitalOptimizer::Armadillo::SCFSolver<double, double>` without a second `#include`.
- The shim test target is gated on `find_package(Armadillo CONFIG QUIET)` so it silently skips on lanes without Armadillo.

## Test plan

- [ ] CI green on all lanes (Repo lane runs the shim test; Python lane stays Armadillo-free and skips it).